### PR TITLE
[templates/default]: layouts for pages

### DIFF
--- a/site/content/demo/docs.md
+++ b/site/content/demo/docs.md
@@ -1,0 +1,7 @@
+---
+title: Demo docs page
+---
+
+Testing demo page with default layout. `(layout/docs.js)`
+
+If the `layout` field is not specified in frontmatter it will default to this (docs) layout.

--- a/site/content/demo/index.md
+++ b/site/content/demo/index.md
@@ -1,0 +1,7 @@
+---
+layout: unstyled
+---
+
+`(layout/unstyled.js)`
+
+Demo page with an unstyled layout *eg. used for homepage with sections*

--- a/site/content/test/index.md
+++ b/site/content/test/index.md
@@ -1,1 +1,0 @@
-# Test page for nested index.md

--- a/templates/default/components/MDX.js
+++ b/templates/default/components/MDX.js
@@ -2,20 +2,20 @@ import Head from 'next/head'
 
 const components = {
   Head,
+  wrapper: ({ layout, ...rest }) => {
+    const Layout = require(`../layouts/${layout}`).default
+    return <Layout {...rest} />
+  }
 }
 
-export default function MdxPage({ children }) {
-  const { Component, frontMatter: { title } } = children;
+export default function MdxPage({ children, ...rest }) {
+  const { Component, frontMatter } = children;
   return (
-    <article className="prose mx-auto p-6">
-      <header>
-        <div className="mb-6">
-          {title && <h1>{title}</h1>}
-        </div>
-      </header>
-      <section>
-        <Component components={components} />
-      </section>
-    </article>
-  );
+    <Component
+      layout={frontMatter.layout}
+      components={components}
+      frontMatter={frontMatter}
+      {...rest}
+    />
+  )
 }

--- a/templates/default/contentlayer.config.js
+++ b/templates/default/contentlayer.config.js
@@ -4,6 +4,7 @@ import remarkGfm from "remark-gfm";
 
 const sharedFields = {
   title: { type: "string" },
+  layout: { type: "string", default: "docs" }
 };
 
 const computedFields = {

--- a/templates/default/layouts/docs.js
+++ b/templates/default/layouts/docs.js
@@ -1,0 +1,13 @@
+export default function DocsLayout ({ children, frontMatter }) {
+    const { title } = frontMatter
+    return (
+      <article className="prose mx-auto p-6">
+        <header>
+          <div className="mb-6">{title && <h1>{title}</h1>}</div>
+        </header>
+        <section>
+          {children}
+        </section>
+      </article>
+    );
+}

--- a/templates/default/layouts/unstyled.js
+++ b/templates/default/layouts/unstyled.js
@@ -1,0 +1,3 @@
+export default function UnstyledLayout ({ children, frontMatter }) {
+    return children
+}

--- a/templates/default/tailwind.config.js
+++ b/templates/default/tailwind.config.js
@@ -1,5 +1,6 @@
 module.exports = {
-  content: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  content: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}', 
+    './layouts/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {},
   },

--- a/templates/default/tests/layouts.spec.js
+++ b/templates/default/tests/layouts.spec.js
@@ -1,0 +1,9 @@
+const { test, expect } = require("@playwright/test")
+
+test.describe('Layout tests', () => {
+    
+    // Test if the default page layout comes from layouts/docs.js
+    test('Default layout', async ({ page }) => {
+        
+    })
+})

--- a/templates/default/tests/pages.spec.js
+++ b/templates/default/tests/pages.spec.js
@@ -24,13 +24,13 @@ test.describe("Pages", () => {
   // })
 
   // Test for nested index.md routes
-  test('Nested index routes [test/index.md]', async ({ page, baseURL }) => {
+  test('Nested index routes [demo/index.md]', async ({ page, baseURL }) => {
     const Page = new MarkdownPage(page);
-    await Page.goto("/test");
+    await Page.goto("/demo");
     await Page.getData(page);
 
-    expect(Page.props.url).toBe("test");
-    expect(Page.props._raw.sourceFilePath).toBe("test/index.md");
+    expect(Page.props.url).toBe("demo");
+    expect(Page.props._raw.sourceFilePath).toBe("demo/index.md");
     
   })
 });


### PR DESCRIPTION
## Classic docs and unstyled layouts for pages

Tasks from #8 
***

This PR adds support for pages to have different layouts if specified in frontmatter. There are two layouts `unstyled` and `docs`

### Tasks

- [x] Frontmatter field `layout: ...` (defaults to 'docs' if not specified)
- [x] Layouts folder with 'unstyled' and 'docs' - `layouts/unstyled.js` & `layouts/docs.js`
- [x] demo pages

### Previews

- Two demo pages in markdown `content/demo`
   - unstyled at [/demo](https://deploy-preview-15--spectacular-dragon-c1015c.netlify.app/demo)
   - docs at [/demo/docs](https://deploy-preview-15--spectacular-dragon-c1015c.netlify.app/demo/docs)