### PR TITLE
Per page props (data) import from json file

### DIFF
--- a/site/content/demo/index.md
+++ b/site/content/demo/index.md
@@ -1,5 +1,6 @@
 ---
 layout: unstyled
+title: demo
 ---
 
 `(layout/unstyled.js)`

--- a/templates/default/data/props.json
+++ b/templates/default/data/props.json
@@ -1,0 +1,18 @@
+{
+  "demo": {
+    "testData": [
+      {
+        "title": "First",
+        "value": 1
+      },
+      {
+        "title": "Second",
+        "value": 2
+      },
+      {
+        "title": "Third",
+        "value": 3
+      }
+    ]
+  }
+}

--- a/templates/default/pages/[[...slug]].js
+++ b/templates/default/pages/[[...slug]].js
@@ -1,15 +1,10 @@
 import { allDocuments } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
 import MdxPage from "../components/MDX";
+import allDocumentsProps from "../data/props.json"
 
-const testData = [
-  { title: "First", value: 1 },
-  { title: "Second", value: 2 },
-  { title: "Third", value: 3 },
-]
-
-export default function Page({ body, ...rest }) {
-  const Component = useMDXComponent(body.code, { testData });
+export default function Page({ body, pageProps, ...rest }) {
+  const Component = useMDXComponent(body.code, pageProps);
   const children = {
     Component,
     frontMatter: {
@@ -23,7 +18,12 @@ export async function getStaticProps({ params }) {
   // params.slug is undefined for root index page
   const urlPath = params.slug ? params.slug.join("/") : '';
   const page = allDocuments.find((p) => p.url === urlPath);
-  return { props: page };
+  const pageTitle = page.title;
+  const pageProps = pageTitle ? allDocumentsProps[pageTitle] : {};
+  return { props: {
+    ...page,
+    pageProps
+  } };
 }
 
 export async function getStaticPaths() {


### PR DESCRIPTION
As per discussion in issue #20, we don't want the user to change `[[...slug]].js`, since it complicates future template upgrades a lot. This approach seems to eliminate this problem:

## Changes
1.  Created `data/props.json` file whose purpose is to store all per-page data
  - key in `props.json` = `title` field value added to the document frontmatter
  - this file (empty) would be a part of the default template
2. `props.json` import in `[[...slug]].json`
  - extended `getStaticProps` to also find page-related data in the imported `props.json` file

## Requirements (from the user)
If a user wants to pass data to components in a given document, he/she needs to:
1. Add a `title` filed to a given document's front matter (I've used the already registered field but we could create another one for this purpose)
2. Add data he/she wants to pass to this document to `data/props.json` under the previously used `title`'s field value

## TODOs
- tweak `[[...slug]].js` code so that it's not necessary to keep an empty `props.json` file (i.e. removing it shouldn't result in an error)
- (maybe) parametrize path to this file so that the user can store this data under whatever name/directory (inside of project dir) he/she wants -> add this path to the `userConfig` file and use this import?