### PR TITLE
renamed "userConfig" & disabled content path setting via env 

### DIFF
--- a/site/content/config.js
+++ b/site/content/config.js
@@ -1,4 +1,4 @@
-const userConfig = {
+const config = {
   title: 'Flowershow',
   // Google analytics key e.g. G-XXXX
   analytics: 'G-RQWLTRWBS2',
@@ -10,4 +10,4 @@ const userConfig = {
   ],
 }
 
-export default userConfig
+export default config

--- a/templates/default/config/siteConfig.js
+++ b/templates/default/config/siteConfig.js
@@ -9,7 +9,10 @@ const defaultConfig = {
   // Google analytics key e.g. G-XXXX
   analytics: '',
   // content source directory for markdown files
-  content: process.env.FLOWERSHOW_CONTENT || 'content',
+  // DO NOT CHANGE THIS VALUE
+  // if you have your notes in another (external) directory,
+  // /content dir should be a symlink to that directory
+  content: 'content',
   // Theme
   navLinks: [
     { href: '/about', name: 'About' },

--- a/templates/default/config/siteConfig.js
+++ b/templates/default/config/siteConfig.js
@@ -31,7 +31,7 @@ const defaultConfig = {
 //  }
 }
 
-import userConfig from '../content/userConfig.js'
+import userConfig from '../content/config.js'
 
 const siteConfig = Object.assign({}, defaultConfig, userConfig)
 


### PR DESCRIPTION
 ## Changes
- moves `content/userConfig.js` to `config.js`
- hardcodes `/content` as a path to markdown notes in `siteConfg.js`

Closes #7