### PR TITLE
`docs/syntax` page adjustments

### DIFF
--- a/site/content/docs/guides.md
+++ b/site/content/docs/guides.md
@@ -2,7 +2,7 @@
 
 Here are our basics guides, that will help you make the most of your Flowershow website:
 1. [[basic-config|Basic configurations with `config.js`]]
-2. [[syntax|Supported markdown and Obsidian syntax]]
+2. [[syntax|Markdown syntax support]]
 3. [[tailwind|Styling with Tailwind]]
 4. [[custom-components|Creating custom components]]
 5. Contentlayer configuration (see docs/essentials/contentlayer)

--- a/site/content/docs/roadmap.md
+++ b/site/content/docs/roadmap.md
@@ -2,7 +2,7 @@
 title: Roadmap
 ---
 
-Flowershow is under active development and there is still a lot of good stuff we plan to ship with upcoming releases. Any contributions are more than welcome!
+Flowershow is under active development and there is a lot of good stuff we plan to ship with upcoming releases. Any contributions are more than welcome!
 
 <div className="border-2 border-slate-400 rounded-md px-4 mb-2">
 ❕ To learn more about the current work status on the features and bugs listed below (and more) check out [GitHub issues](https://github.com/flowershow/flowershow/issues) in Flowershow repo.

--- a/site/content/docs/syntax.md
+++ b/site/content/docs/syntax.md
@@ -5,9 +5,11 @@ Flowershow was designed with Obsidian users in mind, and so, it aims to fully su
 ---
 
 ## CommonMark
+
 Here are some of the CommonMark syntax elements supported by Flowershow.
 
 ### ✅ Thematic breaks
+
 Thematic breaks made with three `*`, `-` or `_` will be converted to HTML `<hr />`
 
 **Example:**
@@ -23,6 +25,7 @@ ___
 ___
 
 ### ✅ Headings
+
 Markdown headings will be converted to HTML `<h1>`-`<h6>` tags.
 
 **Example:**
@@ -130,6 +133,7 @@ Here is some code: `print("hello world!")`
 [Link to roadmap](/docs/roadmap)
 
 ### ✅ Images
+
 ![tulip](https://images.fineartamerica.com/images/artworkimages/mediumlarge/2/abstract-flowers-rose-sciberras.jpg)
 
 ### 🚧 Indented code blocks
@@ -140,7 +144,7 @@ Here is some code: `print("hello world!")`
 		indented code block
 ```
 
-**Renders as:**
+**Renders as:**  
 	a simple
 		indented code block
 
@@ -206,7 +210,22 @@ Check out Flowershow at https://flowershow.app!
 
 ---
 
-## Obsidian extensions
+## Other extensions
+
+### ✅ Obisidian internal links (Wiki links)
+
+Wiki links are hyperlinks that give one-click access to other pages on the site. These are usually denoted with double square brackets `[[some_page]]` and Obsidian would generate the reference to that page automatically.
+
+Flowershow will convert internal links to HTML `a` tags, with their `href` attributes pointing to the location referenced by original internal links.
+
+#### Internal link types
+
+* ✅ Link to a page, e.g. `[[roadmap]]`, which renders as [[roadmap]]
+* ✅ Link to a page with a custom name, e.g.  `[[roadmap|Planned Features]]`, which renders as [[roadmap|Planned Features]] 
+* 🚧 Link to a specific heading within a given page `[[roadmap#Planned features 🚧]]`
+* 🚧 Link to a specific heading within a given page with a custom name, e.g. `[[roadmap#Planned features 🚧|Work in progress...]]`
+* 🚧 Link to a specific block (paragraph) within a given page, e.g. `[[roadmap#Planned features 🚧|Work in progress...]]`
+* 🚧 Link to a file, e.g. `![[park.png]]`
 
 ### ✅ Footnotes
 
@@ -236,20 +255,6 @@ mymeta: Some info
 
 The `title` and `description` fields are pulled from the MDX file and processed using `gray-matter`. Additionally, links are rendered using a custom component passed to `next-mdx-remote`.
 
-### ✅/🚧 Internal linking (Wiki links)
-
-Wiki links are hyperlinks that give one-click access to other pages on the site. These are usually denoted with double square brackets `[[some_page]]` and Obsidian would generate the reference to that page automatically.
-
-Flowershow will convert internal links to HTML `a` tags, with their `href` attributes pointing to the location referenced by original internal links.
-
-#### Internal link types
-* ✅ Link to a page, e.g. `[[roadmap]]`, which renders as [[roadmap]]
-* ✅ Link to a page with a custom name, e.g.  `[[roadmap|Planned Features]]`, which renders as [[roadmap|Planned Features]] 
-* 🚧 Link to a specific heading within a given page `[[roadmap#Planned features 🚧]]`
-* 🚧 Link to a specific heading within a given page with a custom name, e.g. `[[roadmap#Planned features 🚧|Work in progress...]]`
-* 🚧 Link to a specific block (paragraph) within a given page, e.g. `[[roadmap#Planned features 🚧|Work in progress...]]`
-* 🚧 Link to a file, e.g. `![[park.png]]`
-
 ### 🚧 Text highlighting
 
 ==I'm Highlighted!== is done using `==I'm Highlighted!==`
@@ -275,32 +280,9 @@ $$\begin{vmatrix}a & b\\ c & d \end{vmatrix}=ad-bc$$
 
 > [!INFO] > Here's a callout block. > It supports **markdown** and [[docs/index|wikilinks]].
 
-### 🚧 Comments
-
-**Example:**
-
-```md
-Here is some inline comments: %%You can't see this text%%
-
-Here is a block comment:
-%%
-It can span
-multiple lines
-%%
-```
-
-**Renders as:**
-
-Here is some inline comments: %%You can't see this text%%
-
-Here is a block comment:
-%%
-It can span
-multiple lines
-%%
-
 ### 🚧 Mermaid diagrams
-Obsidian uses [Mermaid](https://mermaid-js.github.io/mermaid/#/)to render diagrams.
+
+Rendering [Mermaid](https://mermaid-js.github.io/mermaid/#/) diagrams.
 
 **Example:**
 ````md
@@ -325,3 +307,39 @@ sequenceDiagram
 <div className="border-2 border-slate-400 rounded-md px-4 my-4">
 🔍 To learn more about the Obsidian extensions refer to the [Obsidian Help site](https://help.obsidian.md/How+to/Format+your+notes). 
 </div>
+
+### 🚧 Excalidraw sketches support
+
+Displaying embedded [Excalidraw](https://excalidraw.com/) sketches.
+
+**Example:**
+```md
+![[customizability-vs-upgradeability-efficient-frontier-2022-06-26]]
+```
+
+**Renders as:**  
+![[customizability-vs-upgradeability-efficient-frontier-2022-06-26]]
+
+### 🚧 Comments
+
+**Example:**
+
+```md
+Here is some inline comments: %%You can't see this text%%
+
+Here is a block comment:
+%%
+It can span
+multiple lines
+%%
+```
+
+**Renders as:**
+
+Here is some inline comments: %%You can't see this text%%
+
+Here is a block comment:
+%%
+It can span
+multiple lines
+%%

--- a/site/content/docs/syntax.md
+++ b/site/content/docs/syntax.md
@@ -1,127 +1,51 @@
-# Markdown and Obsidian syntax basics
+# Markdown syntax support
 
-Here are some of the Obsidian syntax elements (CommonMark, GFM, and others) supported by Flowershow.
+Flowershow was designed with Obsidian users in mind, and so, it aims to fully support Obsidian syntax, including **CommonMark**, **GitHub Flavoured Markdown** and **Obsidian extensions**, like Wiki links.
 
-## Auto-linking
+---
 
-All external links will be automatically converted to html anchor tags.
+## CommonMark
+Here are some of the CommonMark syntax elements supported by Flowershow.
+
+### ✅ Thematic breaks
+Thematic breaks made with three `*`, `-` or `_` will be converted to HTML `<hr />`
 
 **Example:**
-
 ```md
-Check out Flowershow at https://flowershow.app!
+***
+---
+___
 ```
 
 **Renders as:**
+***
+---
+___
 
-Check out Flowershow at https://flowershow.app!
-
-## Footnotes
-
-**Example:**
-
-```md
-Roses are red... [^1]
-
-[^1]: ...violets are blue.
-```
-
-Roses are red... [^1]
-
-[^1]: ...violets are blue.
-
-## Markdown tables
+### ✅ Headings
+Markdown headings will be converted to HTML `<h1>`-`<h6>` tags.
 
 **Example:**
-
 ```md
-| Left | Center | Right |
-| :--- |  :---: |  ---: |
-| 1    | 2      | 3     |
+# Heading 1
+...
+###### Heading 6
 ```
 
 **Renders as:**
+All the headings on this page 🙂.
 
-| Left | Center | Right |
-| :--- |  :---: |  ---: |
-| 1    | 2      | 3     |
-
-## Task lists
-
-**Example:**
-
-```md
-* [x] one thing to do
-* [ ] a second thing to do
-```
-
-**Renders as:**
-
-* [x] one thing to do
-* [ ] a second thing to do
-
-## Text formatting
+### ✅ Emphasis
 
 **I'm Bold!** is done using `**I'm Bold!**`  
+__I'm Bold!__ is done using `__I'm Bold!__`
 
-_I'm Italic!_ is done using `*I'm Italic!*`
+*I'm Italic!* is done using `*I'm Italic!*`  
+*I'm Italic!* is done using `_I'm Italic!_`
 
-~~I'm CrossedOut!~~ is done using `~~I'm CrossedOut!~~`
+### ✅ Fenced code blocks with code highlighting
 
-## Blockquotes
-
-**Example:**
-
-```md
-> Roses are red, violets are blue.
-```
-
-**Renders as:**
-
-> Roses are red, violets are blue.
-
-## Nested blockquotes
-
-**Example:**
-
-```md
-> How much wood could a woodchuck chuck,
-> if a woodchuck could chuck wood?
->> As much wood as a woodchuck could chuck,
->> if a woodchuck could chuck wood.
-```
-
-**Renders as:**
-
-> How much wood could a woodchuck chuck,
-> if a woodchuck could chuck wood?
->> As much wood as a woodchuck could chuck,
->> if a woodchuck could chuck wood.
-
-## Obsidian internal links
-
-Wiki links are hyperlinks that give one-click access to other pages on the site. These are usually denoted with double square brackets `[[some_page]]` and Obsidian would generate the reference to that page automatically.
-
-Flowershow will convert internal links to HTML `a` tags, with their `href` attributes pointing to the location referenced by original internal links.
-
-### Internal link types
-**Currently supported by Flowershow:**
-
-* Link to a page, e.g. `[[roadmap]]`, which renders as [[docs/index]]
-* Link to a page with a custom name, e.g.  `[[roadmap|Planned Features]]`, which renders as [[docs/index|Planned Features]] 
-
-🚧 **We're currently working on support for these types:**
-* Link to a specific heading within a given page `[[roadmap#Planned features 🚧]]`
-* Link to a specific heading within a given page with a custom name, e.g. `[[roadmap#Planned features 🚧|Work in progress...]]`
-* Link to a specific block (paragraph) within a given page, e.g. `[[roadmap#Planned features 🚧|Work in progress...]]`
-* Link to a file, e.g. `![[abstract-flowers.png]]`
-
-## Code blocks
-
-Markdown code blocks will be parsed as `pre` tags with support for code highlighting in respective languages using rehype-prism-plus plugin. 
-
-- copy/paste button included on hover
-- style used - VS Code Dark+ from https://github.com/PrismJS/prism-themes
+Code blocks created with backtics will be parsed as `pre` tags with support for code highlighting in respective languages and copy/paste button included on hover.
 
 **Javascript example:**
 
@@ -147,7 +71,158 @@ class Example:
 git commit && git push
 ```
 
-## Frontmatter
+### ✅ Blockquotes
+
+**Example:**
+
+```md
+> Roses are red, violets are blue.
+```
+
+**Renders as:**
+
+> Roses are red, violets are blue.
+
+### ✅ Lists
+
+**Example:**
+
+```md
+- one
+- two
+
+1. one
+2. two
+	- one
+	- two
+```
+
+**Renders as:**
+
+- one
+- two
+
+1. one
+2. two
+	- one
+	- two
+
+### ✅ Inline code
+
+**Example:**
+```md
+Here is some code: `print("hello world!")`
+```
+
+**Renders as:**
+
+Here is some code: `print("hello world!")`
+
+### ✅ Links
+
+**Example:**
+```md
+[Link to roadmap](/docs/roadmap)
+```
+
+**Renders as:**
+
+[Link to roadmap](/docs/roadmap)
+
+### ✅ Images
+![tulip](https://images.fineartamerica.com/images/artworkimages/mediumlarge/2/abstract-flowers-rose-sciberras.jpg)
+
+### 🚧 Indented code blocks
+
+**Example:**
+```md
+	a simple
+		indented code block
+```
+
+**Renders as:**
+	a simple
+		indented code block
+
+<div className="border-2 border-slate-400 rounded-md px-4 my-4">
+🔍 To learn more about the Markdown syntax refer to the [CommonMark specification](https://spec.commonmark.org/0.30/). 
+</div>
+
+---
+
+## GitHub Flavored Markdown (GFM) extensions
+
+### ✅ Tables
+
+**Example:**
+
+```md
+| Left | Center | Right |
+| :--- |  :---: |  ---: |
+| 1    | 2      | 3     |
+```
+
+**Renders as:**
+
+| Left | Center | Right |
+| :--- |  :---: |  ---: |
+| 1    | 2      | 3     |
+
+### ✅ Task lists
+
+**Example:**
+
+```md
+* [x] one thing to do
+* [ ] a second thing to do
+	* [ ] another thing to do!
+```
+
+**Renders as:**
+
+* [x] one thing to do
+* [ ] a second thing to do
+	* [ ] another thing to do!
+
+### ✅ Strikethrough
+
+~~I'm CrossedOut!~~ is done using `~~I'm CrossedOut!~~`
+
+### ✅ Autolinks
+
+**Example:**
+
+```md
+Check out Flowershow at https://flowershow.app!
+```
+
+**Renders as:**
+
+Check out Flowershow at https://flowershow.app!
+
+<div className="border-2 border-slate-400 rounded-md px-4 my-4">
+🔍 To learn more about the GitHub Flavored Markdown syntax refer to the [GFM specification](https://github.github.com/gfm/). 
+</div>
+
+---
+
+## Obsidian extensions
+
+### ✅ Footnotes
+
+**Example:**
+
+```md
+Roses are red... [^1]
+
+[^1]: ...violets are blue.
+```
+
+Roses are red... [^1]
+
+[^1]: ...violets are blue.
+
+### ✅ Frontmatter
 
 You can add metadata to your pages, by adding key-value pairs to frontmatter, e.g.:
 
@@ -161,36 +236,32 @@ mymeta: Some info
 
 The `title` and `description` fields are pulled from the MDX file and processed using `gray-matter`. Additionally, links are rendered using a custom component passed to `next-mdx-remote`.
 
----
+### ✅/🚧 Internal linking (Wiki links)
 
-We are intensively working to support the whole range of Obsidian syntax elements, but there is still a lot work ahead. If you would like to [contribute](https://github.com/flowershow/flowershow#contributing), you are more than welcome!
+Wiki links are hyperlinks that give one-click access to other pages on the site. These are usually denoted with double square brackets `[[some_page]]` and Obsidian would generate the reference to that page automatically.
 
-## Text highlighting  🚧
+Flowershow will convert internal links to HTML `a` tags, with their `href` attributes pointing to the location referenced by original internal links.
+
+#### Internal link types
+* ✅ Link to a page, e.g. `[[roadmap]]`, which renders as [[roadmap]]
+* ✅ Link to a page with a custom name, e.g.  `[[roadmap|Planned Features]]`, which renders as [[roadmap|Planned Features]] 
+* 🚧 Link to a specific heading within a given page `[[roadmap#Planned features 🚧]]`
+* 🚧 Link to a specific heading within a given page with a custom name, e.g. `[[roadmap#Planned features 🚧|Work in progress...]]`
+* 🚧 Link to a specific block (paragraph) within a given page, e.g. `[[roadmap#Planned features 🚧|Work in progress...]]`
+* 🚧 Link to a file, e.g. `![[park.png]]`
+
+### 🚧 Text highlighting
 
 ==I'm Highlighted!== is done using `==I'm Highlighted!==`
 
-## Multiline blockquotes 🚧
-
-**Example:**
-
-```md
-> Roses are red,
-> violets are blue.
-```
-
-**Renders as:**
-
-> Roses are red  
-> violets are blue.
-
-## Math 🚧
+### 🚧 Math
 
 **Example:**
 ```md
 $$\begin{vmatrix}a & b\\ c & d \end{vmatrix}=ad-bc$$
 ```
 
-## Callouts 🚧
+### 🚧 Callouts
 
 **Example:**
 
@@ -204,7 +275,7 @@ $$\begin{vmatrix}a & b\\ c & d \end{vmatrix}=ad-bc$$
 
 > [!INFO] > Here's a callout block. > It supports **markdown** and [[docs/index|wikilinks]].
 
-## Comments 🚧
+### 🚧 Comments
 
 **Example:**
 
@@ -228,3 +299,29 @@ It can span
 multiple lines
 %%
 
+### 🚧 Mermaid diagrams
+Obsidian uses [Mermaid](https://mermaid-js.github.io/mermaid/#/)to render diagrams.
+
+**Example:**
+````md
+```mermaid
+sequenceDiagram
+    Alice->>+John: Hello John, how are you?
+    Alice->>+John: John, can you hear me?
+    John-->>-Alice: Hi Alice, I can hear you!
+    John-->>-Alice: I feel great!
+```
+````
+
+**Renders as:**
+```mermaid
+sequenceDiagram
+    Alice->>+John: Hello John, how are you?
+    Alice->>+John: John, can you hear me?
+    John-->>-Alice: Hi Alice, I can hear you!
+    John-->>-Alice: I feel great!
+```
+
+<div className="border-2 border-slate-400 rounded-md px-4 my-4">
+🔍 To learn more about the Obsidian extensions refer to the [Obsidian Help site](https://help.obsidian.md/How+to/Format+your+notes). 
+</div>


### PR DESCRIPTION
## Changes
- syntax elements in the `docs/syntax` page split into three sections: CommonMark, GFM and Obsidian extensions (based on CommonMark and GFM specs, and Obsidian docs)
- a few more syntax elements added
- added "callouts" at the end of each section pointing to CommonMark and GFM specs, and Obsidian docs at the end of corresponding sections (for users to learn more about each syntax and so that we don't need to write down everything that's already there)