### PR TITLE
Support transclusion links for images

### DIFF
--- a/site/content/docs/syntax.md
+++ b/site/content/docs/syntax.md
@@ -225,7 +225,7 @@ Flowershow will convert internal links to HTML `a` tags, with their `href` attri
 * 🚧 Link to a specific heading within a given page `[[roadmap#Planned features 🚧]]`
 * 🚧 Link to a specific heading within a given page with a custom name, e.g. `[[roadmap#Planned features 🚧|Work in progress...]]`
 * 🚧 Link to a specific block (paragraph) within a given page, e.g. `[[roadmap#Planned features 🚧|Work in progress...]]`
-* ✅ Link to an image file, e.g. `![[park.png]]` will be rendered as shown below
+* ✅ Link to an image file with supported image formats - png, jpg and jpeg, eg. `![[park.png]]` which renders as:
     ![[park.png]]
 
 ### ✅ Footnotes

--- a/site/content/docs/syntax.md
+++ b/site/content/docs/syntax.md
@@ -225,7 +225,8 @@ Flowershow will convert internal links to HTML `a` tags, with their `href` attri
 * 🚧 Link to a specific heading within a given page `[[roadmap#Planned features 🚧]]`
 * 🚧 Link to a specific heading within a given page with a custom name, e.g. `[[roadmap#Planned features 🚧|Work in progress...]]`
 * 🚧 Link to a specific block (paragraph) within a given page, e.g. `[[roadmap#Planned features 🚧|Work in progress...]]`
-* 🚧 Link to a file, e.g. `![[park.png]]`
+* ✅ Link to an image file, e.g. `![[park.png]]` will be rendered as shown below
+    ![[park.png]]
 
 ### ✅ Footnotes
 

--- a/site/content/test/page-4.md
+++ b/site/content/test/page-4.md
@@ -1,0 +1,7 @@
+# remark-wiki-link-plus
+
+## Test transclusion links (images)
+
+This image wiki link `![[obsidian_dark.png]]` will render as below:
+
+![[obsidian_dark.png]]

--- a/site/content/test/page-4.md
+++ b/site/content/test/page-4.md
@@ -1,7 +1,0 @@
-# remark-wiki-link-plus
-
-## Test transclusion links (images)
-
-This image wiki link `![[obsidian_dark.png]]` will render as below:
-
-![[obsidian_dark.png]]

--- a/templates/default/package-lock.json
+++ b/templates/default/package-lock.json
@@ -24,7 +24,7 @@
         "remark-math": "^5.1.1",
         "remark-slug": "^7.0.0",
         "remark-toc": "^8.0.0",
-        "remark-wiki-link-plus": "^1.0.1"
+        "remark-wiki-link-plus": "^1.0.2"
       },
       "devDependencies": {
         "@playwright/test": "^1.22.2",
@@ -6181,9 +6181,9 @@
       }
     },
     "node_modules/remark-wiki-link-plus": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/remark-wiki-link-plus/-/remark-wiki-link-plus-1.0.1.tgz",
-      "integrity": "sha512-TQxMxJAx2uKOKm8vSuGQaTdzN1PfphoHKAD26KH229R641krJk/LWDuzGE6VoaZPQ96IA8rTvY3I0N/0flrqRA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-wiki-link-plus/-/remark-wiki-link-plus-1.0.2.tgz",
+      "integrity": "sha512-w81Z52gWC8GYcq6vO/BWUx5zPk6nIZ6Hc/y5npF91fqGpbeQO1Eq5R7sklODCcX7idfqk92UOo3XRsdXALKbEg==",
       "dependencies": {
         "@babel/runtime": "^7.4.4",
         "mdast-util-wiki-link": "^0.0.2",
@@ -11719,9 +11719,9 @@
       }
     },
     "remark-wiki-link-plus": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/remark-wiki-link-plus/-/remark-wiki-link-plus-1.0.1.tgz",
-      "integrity": "sha512-TQxMxJAx2uKOKm8vSuGQaTdzN1PfphoHKAD26KH229R641krJk/LWDuzGE6VoaZPQ96IA8rTvY3I0N/0flrqRA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-wiki-link-plus/-/remark-wiki-link-plus-1.0.2.tgz",
+      "integrity": "sha512-w81Z52gWC8GYcq6vO/BWUx5zPk6nIZ6Hc/y5npF91fqGpbeQO1Eq5R7sklODCcX7idfqk92UOo3XRsdXALKbEg==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "mdast-util-wiki-link": "^0.0.2",

--- a/templates/default/package.json
+++ b/templates/default/package.json
@@ -27,7 +27,7 @@
     "remark-math": "^5.1.1",
     "remark-slug": "^7.0.0",
     "remark-toc": "^8.0.0",
-    "remark-wiki-link-plus": "^1.0.1"
+    "remark-wiki-link-plus": "^1.0.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.22.2",


### PR DESCRIPTION
## Adding support for transclusion links (images)

This PR adds the feature to support transclusion links for images as used in Obsidian. It parses `![[Image.png]]` as an image element `<img src="assets/images/Image.png" className="internal" />`

### Tasks
- [x] bump remark-wiki-link-plus to latest package version which is now v1.0.2
- [x] create test page in [/test/page-4](https://deploy-preview-87--spectacular-dragon-c1015c.netlify.app/test/page-4)

### Notes

Docs for this support is mentioned in [/docs/syntax](https://flowershow.app/docs/syntax)

### Example screenshot
![Screen Shot 2022-08-11 at 4 33 25 PM](https://user-images.githubusercontent.com/42637597/184139377-cbf74317-1718-40ba-a411-67bb1202f4a4.png)

