### PR TITLE
[SEO]: Seo fixes and default configs

### DIFF
--- a/site/content/config.js
+++ b/site/content/config.js
@@ -1,6 +1,5 @@
 const config = {
   title: 'Flowershow',
-  description: 'Turn your markdown notes into an elegant website and tailor it to your needs. Flowershow is easy to use, fully-featured, Obsidian compatible and open-source.',
   analytics: 'G-RQWLTRWBS2',
   navLinks: [
     { href: '/#overview', name: 'Overview' },
@@ -10,7 +9,11 @@ const config = {
     { href: 'https://github.com/flowershow/flowershow/discussions', name: 'Forum' },
   ],
   nextSeo: {
+    title: 'Flowershow',
+    description: 'Turn your markdown notes into an elegant website and tailor it to your needs. Flowershow is easy to use, fully-featured, Obsidian compatible and open-source.',
+    canonical: 'https://previews-823b8d.netlify.live',
     openGraph: {
+      title: 'Flowershow',
       images: [
         {
           url: 'https://flowershow.app/assets/images/frontpage-screenshot.jpg',

--- a/templates/default/components/Layout.js
+++ b/templates/default/components/Layout.js
@@ -7,9 +7,6 @@ import Header from './Nav'
 export default function Layout({ children, title='' }) {
   return (
     <>
-      <NextSeo
-        title={title}
-        />
       <Head>
         <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>💐</text></svg>" />
         <meta charSet="utf-8" />

--- a/templates/default/components/MDX.js
+++ b/templates/default/components/MDX.js
@@ -1,7 +1,7 @@
 import { NextSeo } from 'next-seo'
 import Head from 'next/head'
 import { Pre } from './Pre'
-import config from '../content/config'
+import siteConfig from '../config/siteConfig'
 
 const components = {
   Head,
@@ -15,24 +15,25 @@ const components = {
 
 export default function MdxPage({ children, ...rest }) {
   const { Component, frontMatter } = children;
+  const seoImageUrl = siteConfig.authorUrl + frontMatter.image
+  
   return (
     <>
       <NextSeo 
-        title={frontMatter?.title}
-        description={frontMatter?.description}
+        title={frontMatter.title}
         openGraph={{
           title: frontMatter.title,
           description: frontMatter.description,
           images: frontMatter.image
             ? [
                 {
-                  url: frontMatter.image,
+                  url: seoImageUrl,
                   width: 1200,
                   height: 627,
-                  alt: title
+                  alt: frontMatter.title
                 }
-              ] : config.nextSeo.openGraph.images,
-          ...config.nextSeo.openGraph,
+              ] 
+            : siteConfig.nextSeo.openGraph.images,
         }}
       />
       <Component

--- a/templates/default/pages/_app.js
+++ b/templates/default/pages/_app.js
@@ -29,12 +29,7 @@ function MyApp({ Component, pageProps }) {
 
   return (
     <ThemeProvider attribute="class" defaultTheme="dark">
-      <DefaultSeo
-        titleTemplate={'%s | ' + siteConfig.title}
-        defaultTitle={siteConfig.title}
-        description={siteConfig.description}
-        {...siteConfig.nextSeo}
-      />
+      <DefaultSeo {...siteConfig.nextSeo} />
       {/* Global Site Tag (gtag.js) - Google Analytics */}
       {siteConfig.analytics &&
         <Script


### PR DESCRIPTION
### SEO titles in config
#57 
***

This PR adds the feature to set nextSeo title in config and fixes the default seo image overrides.

### Tasks
- [x] set title and description in user config file `config.js` for default seo
- [x] fix images overrides and url
- [x] remove nextSeo from layout

### Notes
- There is no `titleTemplate` here as suggested in #57 comments. If we are setting a `titleTemplate` in config, then it appears twice for pages without a frontmatter title. This is because the title is set in config already and is never undefined.
  <img width="289" alt="Screen Shot 2022-08-24 at 3 44 24 PM" src="https://user-images.githubusercontent.com/42637597/186419912-225837b2-e616-4105-9dbf-b5dcc4ca2cbe.png">