### PR TITLE
[Pages]: All page listing

### DIFF
--- a/site/content/config.js
+++ b/site/content/config.js
@@ -8,6 +8,7 @@ const config = {
     { href: '/docs/roadmap', name: 'Roadmap' },
     { href: '/about', name: 'About' },
     { href: 'https://github.com/flowershow/flowershow/discussions', name: 'Forum' },
+    { href: '/_all', name: 'All' },
   ],
   nextSeo: {
     titleTemplate: '%s | Flowershow',

--- a/templates/default/components/Layout.js
+++ b/templates/default/components/Layout.js
@@ -31,6 +31,11 @@ export default function Layout({ children, title='' }) {
                 </a>
               </Link>
             ))}
+            <Link href="/_all">
+              <a className="inline-flex items-center mr-6 px-1 pt-1 font-regular hover:text-slate-300 no-underline">
+                All
+              </a>
+            </Link>
           </div>
           <p className="flex items-center justify-center">
             Made with

--- a/templates/default/components/Layout.js
+++ b/templates/default/components/Layout.js
@@ -31,11 +31,6 @@ export default function Layout({ children, title='' }) {
                 </a>
               </Link>
             ))}
-            <Link href="/_all">
-              <a className="inline-flex items-center mr-6 px-1 pt-1 font-regular hover:text-slate-300 no-underline">
-                All
-              </a>
-            </Link>
           </div>
           <p className="flex items-center justify-center">
             Made with

--- a/templates/default/pages/_all.js
+++ b/templates/default/pages/_all.js
@@ -1,0 +1,53 @@
+import { NextSeo } from "next-seo"
+import { allPages } from "contentlayer/generated"
+
+export default function All({ pages }) {
+  const labels = new Set(pages.map((p) => p.wikiPage.charAt(0)))
+  return (
+    <>
+      <NextSeo title="All pages" />
+      <div className="prose dark:prose-invert p-6 mx-auto">
+        <h1>A-Z Index</h1>
+        {Array.from(labels).map((pageTitle) => (
+          <div key={pageTitle} className="ml-2 pt-2">
+            <h3>{pageTitle}</h3>
+            <hr className="m-0 w-full border-black dark:border-gray-700" />
+            <ul className="list-disc flex flex-wrap">
+              {pages.map(
+                ({ wikiPage, wikiPath }) =>
+                  pageTitle === wikiPage.charAt(0) && (
+                    <li key={wikiPath} className="pr-8 w-fit">
+                      <a href={wikiPath}>{wikiPage}</a>
+                    </li>
+                  )
+              )}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}
+
+export async function getStaticProps() {
+  const pages = allPages
+    .map((page) => {
+      const wikiPath = page._raw.flattenedPath
+      const wikiPage = wikiPath
+        .split("/")
+        .pop()
+        .replace(/-/g, " ")
+        .replace(
+          /^(\w)(.+)/,
+          (match, p1, p2) => p1.toUpperCase() + p2.toLowerCase()
+        );
+
+      return { wikiPage, wikiPath };
+    })
+    .filter(page => page.wikiPath !== '') // exclude homepage
+    .sort((a, b) => a.wikiPage.localeCompare(b.wikiPage))
+
+  return {
+    props: { pages }
+  }
+}


### PR DESCRIPTION
### Add an a-z index page
Resolves #98 
***

Merging this PR will add a page at the route [/_all](https://deploy-preview-129--spectacular-dragon-c1015c.netlify.app/_all) which contains a sorted list of all other pages on the website.

### Tasks
- [x] Add all page
- [x] Add the link to the page in nav/footer