### PR TITLE
[#111]: Fixes to flowershow

### DIFF
--- a/site/content/config.js
+++ b/site/content/config.js
@@ -10,6 +10,7 @@ const config = {
     { href: 'https://github.com/flowershow/flowershow/discussions', name: 'Forum' },
     { href: '/_all', name: 'All' },
   ],
+  github: "https://github.com/flowershow/flowershow",
   nextSeo: {
     titleTemplate: '%s | Flowershow',
     description: 'Turn your markdown notes into an elegant website and tailor it to your needs. Flowershow is easy to use, fully-featured, Obsidian compatible and open-source.',

--- a/templates/default/components/Link.js
+++ b/templates/default/components/Link.js
@@ -1,0 +1,22 @@
+import Link from 'next/link'
+
+const CustomLink = ({ href, ...rest }) => {
+  const isInternalLink = href && href.startsWith('/')
+  const isAnchorLink = href && href.startsWith('#')
+
+  if (isInternalLink) {
+    return (
+      <Link href={href}>
+        <a {...rest} />
+      </Link>
+    )
+  }
+
+  if (isAnchorLink) {
+    return <a href={href} {...rest} />
+  }
+
+  return <a target="_blank" rel="noopener noreferrer" href={href} {...rest} />
+}
+
+export default CustomLink

--- a/templates/default/components/MDX.js
+++ b/templates/default/components/MDX.js
@@ -1,11 +1,15 @@
+import { Fragment } from 'react'
 import { NextSeo } from 'next-seo'
 import Head from 'next/head'
+import CustomLink from './Link'
 import { Pre } from './Pre'
 import siteConfig from '../config/siteConfig'
 
 const components = {
   Head,
+  a: CustomLink,
   pre: Pre,
+  svg: props => <Fragment {...props} />,
   GlobalTest: ({children}) => <h1 className="bg-red-300">{children}</h1>,
   wrapper: ({ layout, ...rest }) => {
     const Layout = require(`../layouts/${layout}`).default
@@ -36,7 +40,7 @@ export default function MdxPage({ children, ...rest }) {
                   alt: frontMatter.title
                 }
               ] 
-            : siteConfig.nextSeo.openGraph.images,
+            : siteConfig?.nextSeo?.openGraph?.images || [],
         }}
       />
       <Component

--- a/templates/default/components/Nav.js
+++ b/templates/default/components/Nav.js
@@ -76,11 +76,11 @@ export default function Header() {
       <div className="relative flex items-center basis-0 justify-end gap-6 sm:gap-8 md:flex-grow">
         <Search />
         <ThemeSelector />
-        <Link href="https://github.com/flowershow/flowershow">
+        {siteConfig.github && <Link href={siteConfig.github}>
           <a className="group" aria-label="GitHub">
             <GitHubIcon className="h-6 w-6 dark:fill-slate-400 group-hover:fill-slate-500 dark:group-hover:fill-slate-300" />
           </a>
-        </Link>
+        </Link>}
       </div>
     </header>
   )

--- a/templates/default/tailwind.config.js
+++ b/templates/default/tailwind.config.js
@@ -8,6 +8,7 @@ module.exports = {
   darkMode: 'class',
   theme: {
     extend: {
+      // support wider width for large screens >1440px eg. in hero
       maxWidth: {
         '8xl': '88rem',
       },


### PR DESCRIPTION
## Various fixes to flowershow
Tasks from #111 
***
This PR fixes the build error from next-seo images not present in config, adds support for next links and proper svg rendering, and adds optional rendering of the github icon if the url is present in config.

### Tasks
- [x] add check for next seo images property if present in `config.js`
- [x] add custom link component for next links
- [x] modify svg component to replace `<p>` with `React.Fragment`
- [x] add github url in `config.js` and optionally render in navbar