### PR TITLE
[content]: Add docs for navbar title, logo and disabling theme

### DIFF
--- a/site/content/docs/config.md
+++ b/site/content/docs/config.md
@@ -23,3 +23,21 @@ const userConfig = {
 
 export default userConfig
 ```
+
+## Navbar Title and Logo
+
+The Title and Logo in the navbar can be set by adding a **navbarTitle** attribute in your config. If you don't want a logo to be displayed in the navbar of your site, then don't include the logo field.
+
+The **navbarTitle** supports adding the following two fields:
+
+* text (your navbar title)
+* logo (path to your logo img file)
+
+```js
+const userConfig = {
+  navBarTitle: {
+    text: 'Your custom title here',
+    logo: '/assets/your-logo.svg'
+  }
+}
+```

--- a/site/content/docs/theme.md
+++ b/site/content/docs/theme.md
@@ -40,6 +40,20 @@ const config = {
 ```
 Note that in dark mode the color of the icon is set to grayscale and once toggled to light mode  it would then render it's original color.
 
+### Disabling the Dark/Light theme
+
+To disable any theme options and not have a theme toggle, set the theme.default option to a blank string value as can be seen below. Doing this will force a light theme on the site.
+
+```js
+// config.js
+
+const config = {
+  theme: {
+    default: ''
+  }
+}
+```
+
 ### Dark theme
 
 ![[dark-theme.jpg]]

--- a/templates/default/.changeset/thick-jars-fetch.md
+++ b/templates/default/.changeset/thick-jars-fetch.md
@@ -1,0 +1,7 @@
+---
+'default': minor
+---
+
+Update documentation for:
+- how to set Navbar title and logo
+- how to disable dark/light theme modes


### PR DESCRIPTION
## Documentation for Navbar Title, Logo and Dark/Light themes
Tasks related to #111 
***

This PR updates the [docs/config]() and [docs/theme]() for instructions on how to add navbar title and logo, and how to disable the dark and light theme modes.

### Tasks
- [x] update docs
- [x] add changeset