### PR TITLE
[contentlayer,docs]: Add callouts plugin and update docs

### DIFF
--- a/site/content/docs/mdx.md
+++ b/site/content/docs/mdx.md
@@ -1,5 +1,3 @@
-import { Callout } from 'components/TempCallout.jsx'
-
 # MDX
 
 ## Table of contents
@@ -8,9 +6,8 @@ Flowershow parses all of your Markdown files as MDX. This means you not only can
 
 Let's see what exactly is MDX and what's so cool about it!
 
-<Callout>
-  A basic familiarity with JSX (React components) and JavaScript might be helpful to understand this chapter, but you can also learn by example and start by tweaking some of our code. Opening [this page](https://github.com/flowershow/flowershow/blob/main/site/content/docs/mdx.md) in your text editor side by side with the rendered version in your browser may also help.
-</Callout>
+> A basic familiarity with JSX (React components) and JavaScript might be helpful to understand this chapter, but you can also learn by example and start by tweaking some of our code. Opening [this page](https://github.com/flowershow/flowershow/blob/main/site/content/docs/mdx.md) in your text editor side by side with the rendered version in your browser may also help.
+
 
 ## What is MDX?
 
@@ -36,9 +33,8 @@ The answer to this question is - yes... and no ¯\_(ツ)\_/¯.
 
 **No**, because Flowershow will parse all your Markdown files as MDX (no matter if you use `.md` or `.mdx` file extension). This means that in the example above, the heading and the block quote will be treated as Markdown, however, the HTML-like looking `<div>` tag will be understood as **JSX** - a React syntax extension to JavaScript that looks like HTML, which allows you to create and use components in your Markdown files.
 
-<Callout>
-  ❕You may have noticed, that we haven't used an HTML `class` attribute on the `<div>` tag above, but rather React's `className` attribute. This is because all HTML elements will be parsed as JSX, which will then be used by React's runtime to render your pages.
-</Callout>
+> [!note]
+> You may have noticed, that we haven't used an HTML `class` attribute on the `<div>` tag above, but rather React's `className` attribute. This is because all HTML elements will be parsed as JSX, which will then be used by React's runtime to render your pages.
 
 How does it work? In short, packages used by Flowershow under the hood compile MDX to JavaScript, which is then used by React to create your website.
 
@@ -46,9 +42,7 @@ How does it work? In short, packages used by Flowershow under the hood compile M
 
 The following sections are just short summaries of what MDX can do. Read [the official MDX docs](https://mdxjs.com/) to learn more.
 
-<Callout>
-  ❕In this document we're going to use Markdown and MDX, as well as HTML and JSX interchangeably. The reason for this is the fact that Flowershow, as we've just learned, parses all Markdown files as MDX files. So, from your perspective, it may be only Markdown that you're using to write your content. However, Flowershow will also understand any MDX-specific additions to it if you were to include them. It follows, that what you may consider HTML blocks, in MDX world is JSX.
-</Callout>
+> ❕In this document we're going to use Markdown and MDX, as well as HTML and JSX interchangeably. The reason for this is the fact that Flowershow, as we've just learned, parses all Markdown files as MDX files. So, from your perspective, it may be only Markdown that you're using to write your content. However, Flowershow will also understand any MDX-specific additions to it if you were to include them. It follows, that what you may consider HTML blocks, in MDX world is JSX.
 
 ### Markdown
 
@@ -124,9 +118,8 @@ export const MyComponent = ({ list }) => {
 };
 ```
 
-<div className="border-2 border-slate-400 rounded-md px-4 mb-4">
-❕ Note, that you should use a `.jsx` extension for any components you want to import into markdown files to make it work.
-</div>
+> [!note]
+> You should use a `.jsx` extension for any components you want to import into markdown files to make it work.
 
 Now, let's import `MyComponent` into this page's markdown.
 
@@ -300,9 +293,7 @@ You can also use comments in expressions with JavaScript's multiline comment syn
 
 If you're not familiar with React or you just need a very basic components that will serve as templates for some parts of Markdown you would normally have to copy over and over again only to make some minor adjustments to them, MDX components may be the way to go. MDX components, in contrast to React components, are written in MDX. And since all MDX files are compiled to components, they can be imported and used the same way as React components.
 
-<Callout>
-The main content of `.mdx` is exported as the default export.
-</Callout>
+> The main content of `.mdx` is exported as the default export.
 
 ### Simple components
 

--- a/site/content/docs/seo.md
+++ b/site/content/docs/seo.md
@@ -2,7 +2,6 @@
 title: SEO Configuration
 description: How to set up SEO in flowershow
 ---
-import { Callout } from 'components/TempCallout.jsx'
 
 ## What is SEO and meta tags
 
@@ -30,9 +29,8 @@ const config = {
 }
 ```
 
-<Callout>
-❕Flowershow uses the NextSEO plugin under the hood, so you can also add other metadata to your pages. See their [documentation](https://github.com/garmeeh/next-seo) to learn more.
-</Callout>
+> [!note]
+> Flowershow uses the NextSEO plugin under the hood, so you can also add other metadata to your pages. See their [documentation](https://github.com/garmeeh/next-seo) to learn more.
 
 ### Set per-page meta-tags
 
@@ -76,9 +74,9 @@ const config = {
 }
 ```
 
-<Callout>
-❕ Note: It is advised to upload an image with the same width and height values as specified above for it to display properly.
-</Callout>
+> [!note]
+> It is advised to upload an image with the same width and height values as specified above for it to display properly.
+
 
 ### Set per-page social media meta tag image
 
@@ -94,9 +92,8 @@ image: /assets/images/your-image-path.jpg
 ---
 ```
 
-<Callout>
-❕ You should set your website's url in your config file so that the correct url path for the image is generated.
-</Callout>
+> [!info]
+> You should set your website's url in your config file so that the correct url path for the image is generated.
 
 ```js
 // in config.js

--- a/templates/default/.changeset/cold-pants-reply.md
+++ b/templates/default/.changeset/cold-pants-reply.md
@@ -1,0 +1,5 @@
+---
+"default": minor
+---
+
+Add remark callouts plugin and use it in docs by replacing callout components.

--- a/templates/default/contentlayer.config.js
+++ b/templates/default/contentlayer.config.js
@@ -5,6 +5,7 @@ import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeMathjax from "rehype-mathjax";
 import rehypePrismPlus from "rehype-prism-plus";
 import rehypeSlug from "rehype-slug";
+import callouts from "remark-callouts";
 import codeExtra from "remark-code-extra";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
@@ -84,6 +85,7 @@ export default makeSource({
       remarkGfm,
       [smartypants, { quotes: false, dashes: "oldschool" }],
       remarkMath,
+      callouts,
       [wikiLinkPlugin, { markdownFolder: siteConfig.content }],
       /** Using the code extra plugin from https://github.com/s0/remark-code-extra
        *  to create new mermaid pre tags to use with mdx-mermaid.
@@ -148,7 +150,8 @@ export default makeSource({
           test(element) {
             return (
               ["h2", "h3", "h4", "h5", "h6"].includes(element.tagName) &&
-              element.properties?.id !== "table-of-contents"
+              element.properties?.id !== "table-of-contents" &&
+              element.properties?.className !== "blockquote-heading"
             );
           },
           content() {

--- a/templates/default/package-lock.json
+++ b/templates/default/package-lock.json
@@ -29,6 +29,7 @@
         "rehype-mathjax": "^4.0.2",
         "rehype-prism-plus": "^1.4.2",
         "rehype-slug": "^5.0.1",
+        "remark-callouts": "^1.0.1",
         "remark-code-extra": "^1.0.1",
         "remark-gfm": "^3.0.0",
         "remark-math": "^5.1.1",
@@ -11173,6 +11174,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-callouts": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/remark-callouts/-/remark-callouts-1.0.1.tgz",
+      "integrity": "sha512-SBZQQZH1UyAKtNd9wC+0xGKDPKZ4STQC7uH6xrpmDk5Q3VPgREQ+eq++d+QFeLcN0eMoLUt8i2+JBe1TPUqNeA==",
+      "dependencies": {
+        "mdast-util-from-markdown": "^1.2.0",
+        "svg-parser": "^2.0.4",
+        "unist-util-visit": "^4.1.0"
+      }
+    },
     "node_modules/remark-code-extra": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/remark-code-extra/-/remark-code-extra-1.0.1.tgz",
@@ -12508,6 +12519,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/svg-parser": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
+      "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
@@ -21738,6 +21754,16 @@
         "unified": "^10.0.0"
       }
     },
+    "remark-callouts": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/remark-callouts/-/remark-callouts-1.0.1.tgz",
+      "integrity": "sha512-SBZQQZH1UyAKtNd9wC+0xGKDPKZ4STQC7uH6xrpmDk5Q3VPgREQ+eq++d+QFeLcN0eMoLUt8i2+JBe1TPUqNeA==",
+      "requires": {
+        "mdast-util-from-markdown": "^1.2.0",
+        "svg-parser": "^2.0.4",
+        "unist-util-visit": "^4.1.0"
+      }
+    },
     "remark-code-extra": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/remark-code-extra/-/remark-code-extra-1.0.1.tgz",
@@ -22754,6 +22780,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+    },
+    "svg-parser": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
+      "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/templates/default/package.json
+++ b/templates/default/package.json
@@ -45,6 +45,7 @@
     "rehype-mathjax": "^4.0.2",
     "rehype-prism-plus": "^1.4.2",
     "rehype-slug": "^5.0.1",
+    "remark-callouts": "^1.0.1",
     "remark-code-extra": "^1.0.1",
     "remark-gfm": "^3.0.0",
     "remark-math": "^5.1.1",

--- a/templates/default/tests/markdownFeatures.spec.js
+++ b/templates/default/tests/markdownFeatures.spec.js
@@ -96,9 +96,9 @@ test.describe.parallel("commonMark", () => {
   });
 
   test("blockquote", async ({ page }) => {
-    await expect(page.locator("#blockquote > blockquote > p")).toContainText(
-      "I am a block quote."
-    );
+    await expect(
+      page.locator("#blockquote > div > blockquote > p")
+    ).toContainText("I am a block quote.");
   });
 
   // test("lists", async ({ page }) => {


### PR DESCRIPTION
## Add  remark-callouts plugin and update docs
Resolves #60 
***

This PR adds:

*  Support for custom Obsidian style callouts to markdown blockquotes using the plugin from https://github.com/flowershow/remark-callouts
* replacements in docs that were using temporary callouts component.

### Tasks
- [x] Add the plugin in contentlayer
- [x] update the docs to use blockquotes with callouts
  - [docs/seo](https://deploy-preview-193--spectacular-dragon-c1015c.netlify.app/docs/seo#setting-global-meta-tags)
  - [docs/mdx](https://deploy-preview-193--spectacular-dragon-c1015c.netlify.app/docs/mdx#what-is-mdx)
 
### Example screenshots

- docs/seo
<img width="707" alt="Screen Shot 2022-10-03 at 8 38 11 PM" src="https://user-images.githubusercontent.com/42637597/193631990-3592e739-7554-4e5d-9346-c0a4b82f082c.png">

- docs/mdx
<img width="699" alt="Screen Shot 2022-10-03 at 8 39 25 PM" src="https://user-images.githubusercontent.com/42637597/193632049-737a67a2-ccb0-496a-a600-1525158f4616.png">
