### PR TITLE
CLI fixes after Alpha release

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flowershow",
-  "version": "0.0.4",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "flowershow",
-      "version": "0.0.4",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flowershow",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Publish your digital garden",
   "bin": {
     "flowershow": "bin/flowershow.js"


### PR DESCRIPTION
Closes #228, #235

**Please don't merge.**

## Changes
- change content/assets symlinks created by the CLI to include relative rather than absolute paths
- add console info about auto-creation of index.md and/or config.js files if they didn't exist in the user's content folder
- bump CLI version

## Todos
- [ ] publish new CLI version to npm