### PR TITLE
Callouts fix and documentation

### DIFF
--- a/site/content/docs/callouts.md
+++ b/site/content/docs/callouts.md
@@ -4,7 +4,7 @@ title: Callouts
 
 With Flowershow you can make use of callouts when using a blockquote. This feature behaves similarly to how Obsidian handles them.
 
-**Example:**
+## Example
 
 ```md
 > [!info] This is cool!
@@ -12,13 +12,13 @@ With Flowershow you can make use of callouts when using a blockquote. This featu
 > It supports **markdown** and [[Internal link|wikilinks]].
 ```
 
-**Renders as:**
+Renders as:
 
 > [!info] This is cool!
 > Here's a callout block.
 > It supports **markdown** and [[docs/index|wikilinks]].
 
-**Supported Types:**
+## Supported Types:
 
 Flowershow supports 13 different Obsidian callout types (with aliases) like note, abstract, todo, or tip. See this [Obsidian docs page](https://help.obsidian.md/How+to/Use+callouts) to learn more about different callout types.
 
@@ -36,6 +36,6 @@ Flowershow supports 13 different Obsidian callout types (with aliases) like note
 - example
 - quote (alias: cite)
 
-<div className="border-2 border-slate-400 rounded-md px-4 my-4">
-🔍 To learn more about the Obsidian extensions refer to the [Obsidian Help site](https://help.obsidian.md/How+to/Format+your+notes). 
-</div>
+> [!info]
+> To learn more about the Obsidian extensions refer to the [Obsidian Help site](https://help.obsidian.md/How+to/Format+your+notes). 
+

--- a/site/content/docs/callouts.md
+++ b/site/content/docs/callouts.md
@@ -1,0 +1,41 @@
+---
+title: Callouts
+---
+
+With Flowershow you can make use of callouts when using a blockquote. This feature behaves similarly to how Obsidian handles them.
+
+**Example:**
+
+```md
+> [!info] This is cool!
+> Here's a callout block.
+> It supports **markdown** and [[Internal link|wikilinks]].
+```
+
+**Renders as:**
+
+> [!info] This is cool!
+> Here's a callout block.
+> It supports **markdown** and [[docs/index|wikilinks]].
+
+**Supported Types:**
+
+Flowershow supports 13 different Obsidian callout types (with aliases) like note, abstract, todo, or tip. See this [Obsidian docs page](https://help.obsidian.md/How+to/Use+callouts) to learn more about different callout types.
+
+- note
+- tip  (alias: hint, important)
+- warning (alias: caution, attention)
+- abstract (alias: summary, tldr)
+- info
+- todo
+- success (alias: check, done)
+- question (alias: help, faq)
+- failure (alias: fail, missing)
+- danger (alias: error)
+- bug
+- example
+- quote (alias: cite)
+
+<div className="border-2 border-slate-400 rounded-md px-4 my-4">
+🔍 To learn more about the Obsidian extensions refer to the [Obsidian Help site](https://help.obsidian.md/How+to/Format+your+notes). 
+</div>

--- a/site/content/docs/syntax.md
+++ b/site/content/docs/syntax.md
@@ -303,27 +303,6 @@ Two '-' will convert to ndash. Three '-' will convert to mdash. Three '.' with o
 ...ellipse\
 ...another ellipse
 
-### Callouts
-
-Flowershow supports 12 different Obsidian callout types (with aliases) like note, abstract, todo, or tip. See this [Obsidian docs page](https://help.obsidian.md/How+to/Use+callouts) to learn more about different callout types.
-
-**Example:**
-
-```md
-> [!info]
-> Here's a callout block.
-> It supports **markdown** and [[Internal link|wikilinks]].
-```
-
-**Renders as:**
-
-> [!info] This is cool!
-> Here's a callout block.
-> It supports **markdown** and [[docs/index|wikilinks]].
-
-<div className="border-2 border-slate-400 rounded-md px-4 my-4">
-🔍 To learn more about the Obsidian extensions refer to the [Obsidian Help site](https://help.obsidian.md/How+to/Format+your+notes). 
-</div>
 
 ### PDF embedding
 

--- a/templates/default/.changeset/four-kids-travel.md
+++ b/templates/default/.changeset/four-kids-travel.md
@@ -1,0 +1,7 @@
+---
+"default": patch
+---
+
+* Bump callouts version `v1.0.1 --> v1.0.2` that contains fixes for case insensitive match eg. `> [!TIP]`
+* Move documentation to [docs/callouts](https://flowershow.app/docs/callouts)
+  - add callouts supported types to docs

--- a/templates/default/package-lock.json
+++ b/templates/default/package-lock.json
@@ -29,7 +29,7 @@
         "rehype-mathjax": "^4.0.2",
         "rehype-prism-plus": "^1.4.2",
         "rehype-slug": "^5.0.1",
-        "remark-callouts": "^1.0.1",
+        "remark-callouts": "^1.0.2",
         "remark-code-extra": "^1.0.1",
         "remark-embed-plus": "^1.0.1",
         "remark-gfm": "^3.0.0",
@@ -11488,9 +11488,9 @@
       }
     },
     "node_modules/remark-callouts": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/remark-callouts/-/remark-callouts-1.0.1.tgz",
-      "integrity": "sha512-SBZQQZH1UyAKtNd9wC+0xGKDPKZ4STQC7uH6xrpmDk5Q3VPgREQ+eq++d+QFeLcN0eMoLUt8i2+JBe1TPUqNeA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-callouts/-/remark-callouts-1.0.2.tgz",
+      "integrity": "sha512-c29i32l++jUmh/Ol3s6s/UMer2gk02/jTitbjcxPY9RFShXE7XjK9cOmZfMeFMgz/TWH1iP3YeeB4ttTzjTLDg==",
       "dependencies": {
         "mdast-util-from-markdown": "^1.2.0",
         "svg-parser": "^2.0.4",
@@ -22369,9 +22369,9 @@
       }
     },
     "remark-callouts": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/remark-callouts/-/remark-callouts-1.0.1.tgz",
-      "integrity": "sha512-SBZQQZH1UyAKtNd9wC+0xGKDPKZ4STQC7uH6xrpmDk5Q3VPgREQ+eq++d+QFeLcN0eMoLUt8i2+JBe1TPUqNeA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-callouts/-/remark-callouts-1.0.2.tgz",
+      "integrity": "sha512-c29i32l++jUmh/Ol3s6s/UMer2gk02/jTitbjcxPY9RFShXE7XjK9cOmZfMeFMgz/TWH1iP3YeeB4ttTzjTLDg==",
       "requires": {
         "mdast-util-from-markdown": "^1.2.0",
         "svg-parser": "^2.0.4",

--- a/templates/default/package.json
+++ b/templates/default/package.json
@@ -45,7 +45,7 @@
     "rehype-mathjax": "^4.0.2",
     "rehype-prism-plus": "^1.4.2",
     "rehype-slug": "^5.0.1",
-    "remark-callouts": "^1.0.1",
+    "remark-callouts": "^1.0.2",
     "remark-code-extra": "^1.0.1",
     "remark-embed-plus": "^1.0.1",
     "remark-gfm": "^3.0.0",


### PR DESCRIPTION
### Summary
***
Resolves #243 

This PR updates the callouts plugin and it's documentation.

### Changes
***
* Bump remark-callouts `v1.0.1 --> v1.0.2` which contains fix for case insensitive match eg. `> [!TIP]`
* Move callouts docs from [docs/syntax](https://flowershow.app/docs/syntax) to [docs/callouts](https://deploy-preview-251--spectacular-dragon-c1015c.netlify.app/docs/callouts)
  - Add documentation for supported types