### PR TITLE
Rename build-static to export

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # flowershow
 
+## 0.0.10
+
+### Patch Changes
+
+- Rename `flowershow build-static` to `flowershow export`.
+
 ## 0.0.9
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flowershow",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Publish your digital garden",
   "bin": {
     "flowershow": "src/bin/cli.js"

--- a/packages/cli/src/bin/cli.js
+++ b/packages/cli/src/bin/cli.js
@@ -7,7 +7,7 @@ import os from "os";
 
 if (os.platform() === "win32") {
   warn(
-    "This may not work as expected. You're trying to run Flowreshow CLI on Windows, which is not supported yet..."
+    "This may not work as expected. You're trying to run Flowreshow CLI on Windows, which is not thoroughly tested. Please submit an issue if you encounter any problems: https://github.com/flowershow/flowershow/issues"
   );
 }
 
@@ -54,16 +54,16 @@ program
   });
 
 program
-  .command("build-static")
-  .description("build static Flowershow website")
+  .command("export")
+  .description("build a static Flowershow website")
   .argument(
     "[project-dir]",
     "Path to the folder where Flowershow template is installed (root folder of .flowershow)",
     "."
   )
   .action(async (projectPath) => {
-    const { default: buildStatic } = await import("../lib/buildStatic.js");
-    buildStatic(projectPath);
+    const { default: buildExport } = await import("../lib/buildExport.js");
+    buildExport(projectPath);
   });
 
 program

--- a/packages/cli/src/e2e/test.bats
+++ b/packages/cli/src/e2e/test.bats
@@ -77,7 +77,7 @@ teardown() {
     run [ -d .flowershow/node_modules ]
     assert_success
 
-    run cli.js build-static
+    run cli.js export
     assert_success
     assert [ -d .flowershow/out ]
     cd .flowershow

--- a/packages/cli/src/lib/buildExport.js
+++ b/packages/cli/src/lib/buildExport.js
@@ -3,7 +3,7 @@ import { execa } from "execa";
 
 import { FLOWERSHOW_FOLDER_NAME } from "./const.js";
 
-export default async function buildStatic(dir) {
+export default async function buildExport(dir) {
   const flowershowDir = path.resolve(dir, FLOWERSHOW_FOLDER_NAME);
 
   const subprocess = execa("npm", ["run", "export"], { cwd: flowershowDir });

--- a/site/content/docs/publish-tutorial.md
+++ b/site/content/docs/publish-tutorial.md
@@ -127,17 +127,17 @@ After running this command, you will now be able to see your website on http://l
 If your ready to publish your site, you can now build it with the following command:
 
 ```bash
-npx flowershow build
-# or npx flowershow build some-parent-dir
+npx flowershow export
+# or npx flowershow export some-parent-dir
 ```
 
 It will create a `.flowershow/.next` folder with your website files ready to be deployed to any hosting provider that supports Node.js.
 
-If you want to deploy it to a static website hosting provider, you need to run the following command instead:
+If you want to deploy it to a static website hosting provider, you can run the following command instead:
 
 ```bash
-npx flowershow build-static
-# or npx flowershow build-static some-parent-dir
+npx flowershow export
+# or npx flowershow export some-parent-dir
 ```
 
 It will create a `.flowershow/out` folder with static files.


### PR DESCRIPTION
Closes #275 

## Changes
- renamed `flowershow build-static` to `flowershow export`
- updated self-publish tutorial