### PR TITLE
Update remark callouts plugin v2.0.0

### DIFF
--- a/packages/template/package-lock.json
+++ b/packages/template/package-lock.json
@@ -30,7 +30,7 @@
         "rehype-mathjax": "^4.0.2",
         "rehype-prism-plus": "^1.4.2",
         "rehype-slug": "^5.0.1",
-        "remark-callouts": "^1.0.2",
+        "remark-callouts": "^2.0.0",
         "remark-code-extra": "^1.0.1",
         "remark-embed-plus": "^1.0.2",
         "remark-gfm": "^3.0.0",
@@ -6606,9 +6606,9 @@
       }
     },
     "node_modules/remark-callouts": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/remark-callouts/-/remark-callouts-1.0.2.tgz",
-      "integrity": "sha512-c29i32l++jUmh/Ol3s6s/UMer2gk02/jTitbjcxPY9RFShXE7XjK9cOmZfMeFMgz/TWH1iP3YeeB4ttTzjTLDg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/remark-callouts/-/remark-callouts-2.0.0.tgz",
+      "integrity": "sha512-kTtBca6NzVNVn71wKMBiliSS/XEtYr6CQgWFQt+s6lkqtHHwHsfP4PxsqFbL98m9nxqlnqTyoYfNr1//u9jrlA==",
       "dependencies": {
         "mdast-util-from-markdown": "^1.2.0",
         "svg-parser": "^2.0.4",
@@ -12810,9 +12810,9 @@
       }
     },
     "remark-callouts": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/remark-callouts/-/remark-callouts-1.0.2.tgz",
-      "integrity": "sha512-c29i32l++jUmh/Ol3s6s/UMer2gk02/jTitbjcxPY9RFShXE7XjK9cOmZfMeFMgz/TWH1iP3YeeB4ttTzjTLDg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/remark-callouts/-/remark-callouts-2.0.0.tgz",
+      "integrity": "sha512-kTtBca6NzVNVn71wKMBiliSS/XEtYr6CQgWFQt+s6lkqtHHwHsfP4PxsqFbL98m9nxqlnqTyoYfNr1//u9jrlA==",
       "requires": {
         "mdast-util-from-markdown": "^1.2.0",
         "svg-parser": "^2.0.4",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -32,7 +32,7 @@
     "rehype-mathjax": "^4.0.2",
     "rehype-prism-plus": "^1.4.2",
     "rehype-slug": "^5.0.1",
-    "remark-callouts": "^1.0.2",
+    "remark-callouts": "^2.0.0",
     "remark-code-extra": "^1.0.1",
     "remark-embed-plus": "^1.0.2",
     "remark-gfm": "^3.0.0",

--- a/packages/template/styles/global.css
+++ b/packages/template/styles/global.css
@@ -1,3 +1,5 @@
+@import "remark-callouts/styles.css";
+
 /* mathjax */
 .math-inline {
   display: flex;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,14 +53,14 @@ importers:
     devDependencies:
       "@changesets/changelog-github": 0.4.7
       "@changesets/cli": 2.25.2
-      "@nrwl/eslint-plugin-nx": 15.0.5_eeg3gclarghfze4o6t6xx3kkfq
-      "@nrwl/jest": 15.0.5_mzmvppv532gkqhi7ksj56p73cq
-      "@nrwl/linter": 15.0.5_6bvy3djy6esm64tr6fz4cuweme
-      "@nrwl/next": 15.0.5_2dkzmcdpdgtlak34nky4ntvnfu
-      "@nrwl/node": 15.0.5_3ko7d6vgwpdgukdpdfx7ebayiq
+      "@nrwl/eslint-plugin-nx": 15.0.5_filcmjizgjn3cotzvnnjl73hwe
+      "@nrwl/jest": 15.0.5_trx2rcki53waib6i65up2uwqby
+      "@nrwl/linter": 15.0.5_vio6jx45e2tgkhx5vlhesjga34
+      "@nrwl/next": 15.0.5_s7ji3jsrghguts2iagnohhmxda
+      "@nrwl/node": 15.0.5_7d46qq6ni4spl2e5lrptozxvbi
       "@nrwl/nx-cloud": 15.0.2
-      "@nrwl/react": 15.0.5_jp7bvx4fptmpt6aiut3ouizo6u
-      "@nrwl/web": 15.0.5_jp7bvx4fptmpt6aiut3ouizo6u
+      "@nrwl/react": 15.0.5_qatfe6ntf4fdpsyekfwphhseru
+      "@nrwl/web": 15.0.5_qatfe6ntf4fdpsyekfwphhseru
       "@playwright/test": 1.27.1
       "@testing-library/react": 13.4.0_biqbaboplfbrettd7655fr4n2y
       "@types/degit": 2.8.3
@@ -70,11 +70,11 @@ importers:
       "@types/react": 18.0.20
       "@types/react-dom": 18.0.6
       "@types/universal-analytics": 0.4.5
-      "@typescript-eslint/eslint-plugin": 5.42.1_edj3z5fb2d4dyl4qibv6szemjm
-      "@typescript-eslint/parser": 5.42.1_oy7hgmlo6357d5kkcjbkfgtg4q
+      "@typescript-eslint/eslint-plugin": 5.42.1_er2pzvpk327s27wxfnvf7drdoy
+      "@typescript-eslint/parser": 5.42.1_wdqgoy3juh7r2u2b4n4o4ol5rq
       babel-jest: 28.1.1_@babel+core@7.20.2
       eslint: 8.15.0
-      eslint-config-next: 13.0.0_oy7hgmlo6357d5kkcjbkfgtg4q
+      eslint-config-next: 13.0.0_wdqgoy3juh7r2u2b4n4o4ol5rq
       eslint-config-prettier: 8.1.0_eslint@8.15.0
       eslint-plugin-import: 2.26.0_cfz7tlvncdyp6u3oeztrozxwbq
       eslint-plugin-jsx-a11y: 6.6.1_eslint@8.15.0
@@ -89,8 +89,8 @@ importers:
       prettier: 2.7.1
       react-test-renderer: 18.2.0_react@18.2.0
       sass: 1.55.0
-      ts-jest: 28.0.5_pfatmudpkfer4fk26itqij7pwu
-      ts-node: 10.9.1_2cnt46lw4tdywdelgueo3bh3pq
+      ts-jest: 28.0.5_tinkr55cgdkjhd4ukaexa5wwju
+      ts-node: 10.9.1_qlbucxx4nxy66tcqp4burcab4y
 
   packages/cli:
     specifiers:
@@ -138,7 +138,7 @@ importers:
       rehype-mathjax: ^4.0.2
       rehype-prism-plus: ^1.4.2
       rehype-slug: ^5.0.1
-      remark-callouts: ^1.0.2
+      remark-callouts: ^2.0.0
       remark-code-extra: ^1.0.1
       remark-embed-plus: ^1.0.2
       remark-gfm: ^3.0.0
@@ -171,7 +171,7 @@ importers:
       rehype-mathjax: 4.0.2
       rehype-prism-plus: 1.5.0
       rehype-slug: 5.1.0
-      remark-callouts: 1.0.2
+      remark-callouts: 2.0.0
       remark-code-extra: 1.0.1
       remark-embed-plus: 1.0.2
       remark-gfm: 3.0.1
@@ -3589,7 +3589,7 @@ packages:
       - debug
     dev: true
 
-  /@nrwl/cypress/15.0.5_jp7bvx4fptmpt6aiut3ouizo6u:
+  /@nrwl/cypress/15.0.5_qatfe6ntf4fdpsyekfwphhseru:
     resolution:
       {
         integrity: sha512-DjckLhzBP2JF9IT7ZlR9E0IoCJ9wzXoLWodmVDCtCLw3+gjjJt3aIF74R56hidPiUkNTfcvPciMpg8b+UL7HQg==,
@@ -3603,16 +3603,16 @@ packages:
       "@babel/core": 7.20.2
       "@babel/preset-env": 7.20.2_@babel+core@7.20.2
       "@cypress/webpack-preprocessor": 5.15.4_xcohdjru5xgrqhvdie6y7w7oeq
-      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.8.4
-      "@nrwl/linter": 15.0.5_6bvy3djy6esm64tr6fz4cuweme
-      "@nrwl/workspace": 15.0.5_7p4kftbl4xdiv7pp73ecrv754e
-      "@phenomnomnominal/tsquery": 4.1.1_typescript@4.8.4
+      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.9.3
+      "@nrwl/linter": 15.0.5_vio6jx45e2tgkhx5vlhesjga34
+      "@nrwl/workspace": 15.0.5_mqtuwqoshjopmdjnatemz7t4rq
+      "@phenomnomnominal/tsquery": 4.1.1_typescript@4.9.3
       babel-loader: 8.3.0_hkczypimj4evef4hfazf6yfxte
       chalk: 4.1.0
       dotenv: 10.0.0
-      fork-ts-checker-webpack-plugin: 7.2.13_qqxisngxjbp7lstdk7boexbu3e
+      fork-ts-checker-webpack-plugin: 7.2.13_ioost42n2pkm3q6vbnx4ypyu7a
       semver: 7.3.4
-      ts-loader: 9.4.1_qqxisngxjbp7lstdk7boexbu3e
+      ts-loader: 9.4.1_ioost42n2pkm3q6vbnx4ypyu7a
       tsconfig-paths-webpack-plugin: 3.5.2
       tslib: 2.4.1
       webpack: 5.74.0
@@ -3635,7 +3635,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@nrwl/devkit/15.0.5_nx@15.0.5+typescript@4.8.4:
+  /@nrwl/devkit/15.0.5_nx@15.0.5+typescript@4.9.3:
     resolution:
       {
         integrity: sha512-7Vsjqn4hqs0XVXWYKL5ZUr4zeSnVN4ThZMpyixVO5KSaZxwFPhHqCKD4Q+NUBE+IpJh9HukZasnXARcvfPqKVw==,
@@ -3643,7 +3643,7 @@ packages:
     peerDependencies:
       nx: ">= 14 <= 16"
     dependencies:
-      "@phenomnomnominal/tsquery": 4.1.1_typescript@4.8.4
+      "@phenomnomnominal/tsquery": 4.1.1_typescript@4.9.3
       ejs: 3.1.8
       ignore: 5.2.0
       nx: 15.0.5
@@ -3653,7 +3653,7 @@ packages:
       - typescript
     dev: true
 
-  /@nrwl/eslint-plugin-nx/15.0.5_eeg3gclarghfze4o6t6xx3kkfq:
+  /@nrwl/eslint-plugin-nx/15.0.5_filcmjizgjn3cotzvnnjl73hwe:
     resolution:
       {
         integrity: sha512-t5qWl4oc3S47youZ9iZ5AfBqUOCT/oo3Fyz7op1v6Lpm72wxojWvV/po9faZJXkUHd8DZEjUrtCMy5xHE/zboA==,
@@ -3665,10 +3665,10 @@ packages:
       eslint-config-prettier:
         optional: true
     dependencies:
-      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.8.4
-      "@nrwl/workspace": 15.0.5_7p4kftbl4xdiv7pp73ecrv754e
-      "@typescript-eslint/parser": 5.42.1_oy7hgmlo6357d5kkcjbkfgtg4q
-      "@typescript-eslint/utils": 5.42.1_oy7hgmlo6357d5kkcjbkfgtg4q
+      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.9.3
+      "@nrwl/workspace": 15.0.5_mqtuwqoshjopmdjnatemz7t4rq
+      "@typescript-eslint/parser": 5.42.1_wdqgoy3juh7r2u2b4n4o4ol5rq
+      "@typescript-eslint/utils": 5.42.1_wdqgoy3juh7r2u2b4n4o4ol5rq
       chalk: 4.1.0
       confusing-browser-globals: 1.0.11
       eslint-config-prettier: 8.1.0_eslint@8.15.0
@@ -3687,7 +3687,7 @@ packages:
       - typescript
     dev: true
 
-  /@nrwl/jest/15.0.5_mzmvppv532gkqhi7ksj56p73cq:
+  /@nrwl/jest/15.0.5_trx2rcki53waib6i65up2uwqby:
     resolution:
       {
         integrity: sha512-x/TMLj67UTcuYUISKl0diJY1hwG8+1o3TU4496RE7W9+mJI/ebrDxmYVQ+YRsO9u8gc6gQioWEaQLrpWaMMqjg==,
@@ -3695,8 +3695,8 @@ packages:
     dependencies:
       "@jest/reporters": 28.1.1
       "@jest/test-result": 28.1.1
-      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.8.4
-      "@phenomnomnominal/tsquery": 4.1.1_typescript@4.8.4
+      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.9.3
+      "@phenomnomnominal/tsquery": 4.1.1_typescript@4.9.3
       chalk: 4.1.0
       dotenv: 10.0.0
       identity-obj-proxy: 3.0.0
@@ -3714,16 +3714,16 @@ packages:
       - typescript
     dev: true
 
-  /@nrwl/js/15.0.5_jp7bvx4fptmpt6aiut3ouizo6u:
+  /@nrwl/js/15.0.5_qatfe6ntf4fdpsyekfwphhseru:
     resolution:
       {
         integrity: sha512-StOFjgy0kC1Xffb8BsxehiKBAjjiNqyPJ69WJQUcM6o4uZbmMM/HcBbadwjvBZG4bxW5tXRbwD6ehsfwD8+EIg==,
       }
     dependencies:
-      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.8.4
-      "@nrwl/jest": 15.0.5_mzmvppv532gkqhi7ksj56p73cq
-      "@nrwl/linter": 15.0.5_6bvy3djy6esm64tr6fz4cuweme
-      "@nrwl/workspace": 15.0.5_7p4kftbl4xdiv7pp73ecrv754e
+      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.9.3
+      "@nrwl/jest": 15.0.5_trx2rcki53waib6i65up2uwqby
+      "@nrwl/linter": 15.0.5_vio6jx45e2tgkhx5vlhesjga34
+      "@nrwl/workspace": 15.0.5_mqtuwqoshjopmdjnatemz7t4rq
       "@parcel/watcher": 2.0.4
       chalk: 4.1.0
       fast-glob: 3.2.7
@@ -3747,7 +3747,7 @@ packages:
       - typescript
     dev: true
 
-  /@nrwl/linter/15.0.5_6bvy3djy6esm64tr6fz4cuweme:
+  /@nrwl/linter/15.0.5_vio6jx45e2tgkhx5vlhesjga34:
     resolution:
       {
         integrity: sha512-4+5ATy8LcK6UwoyA401vSCn8jkzBAderBfR2K/KLQU58XBGdcvsSa19QrCdeuAtohxwPihaWnZj4eLrx/sT5Ig==,
@@ -3758,9 +3758,9 @@ packages:
       eslint:
         optional: true
     dependencies:
-      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.8.4
-      "@nrwl/jest": 15.0.5_mzmvppv532gkqhi7ksj56p73cq
-      "@phenomnomnominal/tsquery": 4.1.1_typescript@4.8.4
+      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.9.3
+      "@nrwl/jest": 15.0.5_trx2rcki53waib6i65up2uwqby
+      "@phenomnomnominal/tsquery": 4.1.1_typescript@4.9.3
       eslint: 8.15.0
       nx: 15.0.5
       tmp: 0.2.1
@@ -3776,7 +3776,7 @@ packages:
       - typescript
     dev: true
 
-  /@nrwl/next/15.0.5_2dkzmcdpdgtlak34nky4ntvnfu:
+  /@nrwl/next/15.0.5_s7ji3jsrghguts2iagnohhmxda:
     resolution:
       {
         integrity: sha512-aIlh8XNvWhT24YtZPS36xw7OTfimA7P5mNnOqcAyvcF+LuD9OHtWeKYCaSk2nd7bwMZka4eCTMZb3RUoXL4zEg==,
@@ -3785,13 +3785,13 @@ packages:
       next: ^13.0.0
     dependencies:
       "@babel/plugin-proposal-decorators": 7.20.2_@babel+core@7.20.2
-      "@nrwl/cypress": 15.0.5_jp7bvx4fptmpt6aiut3ouizo6u
-      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.8.4
-      "@nrwl/jest": 15.0.5_mzmvppv532gkqhi7ksj56p73cq
-      "@nrwl/linter": 15.0.5_6bvy3djy6esm64tr6fz4cuweme
-      "@nrwl/react": 15.0.5_jp7bvx4fptmpt6aiut3ouizo6u
-      "@nrwl/webpack": 15.0.5_kxpxnqyypwota5o2pfrwpmkvpq
-      "@nrwl/workspace": 15.0.5_7p4kftbl4xdiv7pp73ecrv754e
+      "@nrwl/cypress": 15.0.5_qatfe6ntf4fdpsyekfwphhseru
+      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.9.3
+      "@nrwl/jest": 15.0.5_trx2rcki53waib6i65up2uwqby
+      "@nrwl/linter": 15.0.5_vio6jx45e2tgkhx5vlhesjga34
+      "@nrwl/react": 15.0.5_qatfe6ntf4fdpsyekfwphhseru
+      "@nrwl/webpack": 15.0.5_erwcncqt4fgkzp4b7pd7nykrye
+      "@nrwl/workspace": 15.0.5_mqtuwqoshjopmdjnatemz7t4rq
       "@svgr/webpack": 6.5.1
       chalk: 4.1.0
       dotenv: 10.0.0
@@ -3799,7 +3799,7 @@ packages:
       ignore: 5.2.0
       next: 13.0.2_jdv2xngbcnqnyxo5snxfrvsuoe
       semver: 7.3.4
-      ts-node: 10.9.1_2cnt46lw4tdywdelgueo3bh3pq
+      ts-node: 10.9.1_qlbucxx4nxy66tcqp4burcab4y
       tsconfig-paths: 3.14.1
       url-loader: 4.1.1_webpack@5.74.0
       webpack-merge: 5.8.0
@@ -3841,18 +3841,18 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@nrwl/node/15.0.5_3ko7d6vgwpdgukdpdfx7ebayiq:
+  /@nrwl/node/15.0.5_7d46qq6ni4spl2e5lrptozxvbi:
     resolution:
       {
         integrity: sha512-4PeOMQEq5NojdlovyTMWYvALkuuea3FcE2GCZ3TwC4RZOdDfcXQndRXdccgnYEW3PsZt7mhNRds7xLOIeaNOGQ==,
       }
     dependencies:
-      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.8.4
-      "@nrwl/jest": 15.0.5_mzmvppv532gkqhi7ksj56p73cq
-      "@nrwl/js": 15.0.5_jp7bvx4fptmpt6aiut3ouizo6u
-      "@nrwl/linter": 15.0.5_6bvy3djy6esm64tr6fz4cuweme
-      "@nrwl/webpack": 15.0.5_kxpxnqyypwota5o2pfrwpmkvpq
-      "@nrwl/workspace": 15.0.5_7p4kftbl4xdiv7pp73ecrv754e
+      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.9.3
+      "@nrwl/jest": 15.0.5_trx2rcki53waib6i65up2uwqby
+      "@nrwl/js": 15.0.5_qatfe6ntf4fdpsyekfwphhseru
+      "@nrwl/linter": 15.0.5_vio6jx45e2tgkhx5vlhesjga34
+      "@nrwl/webpack": 15.0.5_erwcncqt4fgkzp4b7pd7nykrye
+      "@nrwl/workspace": 15.0.5_mqtuwqoshjopmdjnatemz7t4rq
       chalk: 4.1.0
       tslib: 2.4.1
     transitivePeerDependencies:
@@ -3903,7 +3903,7 @@ packages:
       - debug
     dev: true
 
-  /@nrwl/react/15.0.5_jp7bvx4fptmpt6aiut3ouizo6u:
+  /@nrwl/react/15.0.5_qatfe6ntf4fdpsyekfwphhseru:
     resolution:
       {
         integrity: sha512-ksvDda0i0XrXDcVaNe39RZ6sHQ8df9zDrhNIp9hCbz69RAUxVQuTJLEAZ5hEHndwZJ6/2tZn1/TWKAkdwiqLiw==,
@@ -3911,16 +3911,16 @@ packages:
     dependencies:
       "@babel/core": 7.20.2
       "@babel/preset-react": 7.18.6_@babel+core@7.20.2
-      "@nrwl/cypress": 15.0.5_jp7bvx4fptmpt6aiut3ouizo6u
-      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.8.4
-      "@nrwl/jest": 15.0.5_mzmvppv532gkqhi7ksj56p73cq
-      "@nrwl/js": 15.0.5_jp7bvx4fptmpt6aiut3ouizo6u
-      "@nrwl/linter": 15.0.5_6bvy3djy6esm64tr6fz4cuweme
-      "@nrwl/storybook": 15.0.5_jp7bvx4fptmpt6aiut3ouizo6u
-      "@nrwl/web": 15.0.5_jp7bvx4fptmpt6aiut3ouizo6u
-      "@nrwl/webpack": 15.0.5_kxpxnqyypwota5o2pfrwpmkvpq
-      "@nrwl/workspace": 15.0.5_7p4kftbl4xdiv7pp73ecrv754e
-      "@phenomnomnominal/tsquery": 4.1.1_typescript@4.8.4
+      "@nrwl/cypress": 15.0.5_qatfe6ntf4fdpsyekfwphhseru
+      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.9.3
+      "@nrwl/jest": 15.0.5_trx2rcki53waib6i65up2uwqby
+      "@nrwl/js": 15.0.5_qatfe6ntf4fdpsyekfwphhseru
+      "@nrwl/linter": 15.0.5_vio6jx45e2tgkhx5vlhesjga34
+      "@nrwl/storybook": 15.0.5_qatfe6ntf4fdpsyekfwphhseru
+      "@nrwl/web": 15.0.5_qatfe6ntf4fdpsyekfwphhseru
+      "@nrwl/webpack": 15.0.5_erwcncqt4fgkzp4b7pd7nykrye
+      "@nrwl/workspace": 15.0.5_mqtuwqoshjopmdjnatemz7t4rq
+      "@phenomnomnominal/tsquery": 4.1.1_typescript@4.9.3
       "@pmmmwh/react-refresh-webpack-plugin": 0.5.8_bgbvhssx5jbdjtmrq4m55itcsu
       "@svgr/webpack": 6.5.1
       chalk: 4.1.0
@@ -3971,15 +3971,15 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@nrwl/rollup/15.0.5_3ko7d6vgwpdgukdpdfx7ebayiq:
+  /@nrwl/rollup/15.0.5_7d46qq6ni4spl2e5lrptozxvbi:
     resolution:
       {
         integrity: sha512-MAqfnmZle51P4GscrzP23or91SVf4pxWrLIooxK2nDljg4eGuHKk2J+lua5fCERi1uBcD/CuoVrL0GUi+6TRJA==,
       }
     dependencies:
-      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.8.4
-      "@nrwl/js": 15.0.5_jp7bvx4fptmpt6aiut3ouizo6u
-      "@nrwl/workspace": 15.0.5_7p4kftbl4xdiv7pp73ecrv754e
+      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.9.3
+      "@nrwl/js": 15.0.5_qatfe6ntf4fdpsyekfwphhseru
+      "@nrwl/workspace": 15.0.5_mqtuwqoshjopmdjnatemz7t4rq
       "@rollup/plugin-babel": 5.3.1_rw3hudt2pmn5afxog7l3b6qtze
       "@rollup/plugin-commonjs": 20.0.0_rollup@2.79.1
       "@rollup/plugin-image": 2.1.1_rollup@2.79.1
@@ -3995,7 +3995,7 @@ packages:
       rollup-plugin-copy: 3.4.0
       rollup-plugin-peer-deps-external: 2.2.4_rollup@2.79.1
       rollup-plugin-postcss: 4.0.2_neo3lunb2qpadwxplzw7r2isgm
-      rollup-plugin-typescript2: 0.31.2_gypgyaqhine6mwjfvh7icfhviq
+      rollup-plugin-typescript2: 0.31.2_k35zwyycrckt5xfsejji7kbwn4
       rxjs: 6.6.7
       tslib: 2.4.1
     transitivePeerDependencies:
@@ -4014,16 +4014,16 @@ packages:
       - typescript
     dev: true
 
-  /@nrwl/storybook/15.0.5_jp7bvx4fptmpt6aiut3ouizo6u:
+  /@nrwl/storybook/15.0.5_qatfe6ntf4fdpsyekfwphhseru:
     resolution:
       {
         integrity: sha512-9oFiC973LaImgdbTIE4u6pQVODWSE1sjTrfgiO39wvS8EezG3i2EsCEiXPl+FkbIB5EFxe17vtjajT8MwAjtug==,
       }
     dependencies:
-      "@nrwl/cypress": 15.0.5_jp7bvx4fptmpt6aiut3ouizo6u
-      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.8.4
-      "@nrwl/linter": 15.0.5_6bvy3djy6esm64tr6fz4cuweme
-      "@nrwl/workspace": 15.0.5_7p4kftbl4xdiv7pp73ecrv754e
+      "@nrwl/cypress": 15.0.5_qatfe6ntf4fdpsyekfwphhseru
+      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.9.3
+      "@nrwl/linter": 15.0.5_vio6jx45e2tgkhx5vlhesjga34
+      "@nrwl/workspace": 15.0.5_mqtuwqoshjopmdjnatemz7t4rq
       dotenv: 10.0.0
       semver: 7.3.4
     transitivePeerDependencies:
@@ -4059,7 +4059,7 @@ packages:
       - debug
     dev: true
 
-  /@nrwl/web/15.0.5_jp7bvx4fptmpt6aiut3ouizo6u:
+  /@nrwl/web/15.0.5_qatfe6ntf4fdpsyekfwphhseru:
     resolution:
       {
         integrity: sha512-5VOO/lEt251oQLcnKq2UW3r/FCh6TrPXF1E03ocvXxmJMg+6tJ0tqo4UQ5UfDx87/8OlGFtp8iRGhh/wRIoMtw==,
@@ -4072,14 +4072,14 @@ packages:
       "@babel/preset-env": 7.20.2_@babel+core@7.20.2
       "@babel/preset-typescript": 7.18.6_@babel+core@7.20.2
       "@babel/runtime": 7.20.1
-      "@nrwl/cypress": 15.0.5_jp7bvx4fptmpt6aiut3ouizo6u
-      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.8.4
-      "@nrwl/jest": 15.0.5_mzmvppv532gkqhi7ksj56p73cq
-      "@nrwl/js": 15.0.5_jp7bvx4fptmpt6aiut3ouizo6u
-      "@nrwl/linter": 15.0.5_6bvy3djy6esm64tr6fz4cuweme
-      "@nrwl/rollup": 15.0.5_3ko7d6vgwpdgukdpdfx7ebayiq
-      "@nrwl/webpack": 15.0.5_kxpxnqyypwota5o2pfrwpmkvpq
-      "@nrwl/workspace": 15.0.5_7p4kftbl4xdiv7pp73ecrv754e
+      "@nrwl/cypress": 15.0.5_qatfe6ntf4fdpsyekfwphhseru
+      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.9.3
+      "@nrwl/jest": 15.0.5_trx2rcki53waib6i65up2uwqby
+      "@nrwl/js": 15.0.5_qatfe6ntf4fdpsyekfwphhseru
+      "@nrwl/linter": 15.0.5_vio6jx45e2tgkhx5vlhesjga34
+      "@nrwl/rollup": 15.0.5_7d46qq6ni4spl2e5lrptozxvbi
+      "@nrwl/webpack": 15.0.5_erwcncqt4fgkzp4b7pd7nykrye
+      "@nrwl/workspace": 15.0.5_mqtuwqoshjopmdjnatemz7t4rq
       babel-plugin-const-enum: 1.2.0_@babel+core@7.20.2
       babel-plugin-macros: 2.8.0
       babel-plugin-transform-typescript-metadata: 0.3.2
@@ -4118,15 +4118,15 @@ packages:
       - webpack-cli
     dev: true
 
-  /@nrwl/webpack/15.0.5_kxpxnqyypwota5o2pfrwpmkvpq:
+  /@nrwl/webpack/15.0.5_erwcncqt4fgkzp4b7pd7nykrye:
     resolution:
       {
         integrity: sha512-xeGL5aTSzwuyps1ddKLR9W1/jZwLtAxaGsFoM4H3MaJFOdRnxAIiB0bwSM7IMJsJnlVaDyaN81W1vFQIBbXxKQ==,
       }
     dependencies:
-      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.8.4
-      "@nrwl/js": 15.0.5_jp7bvx4fptmpt6aiut3ouizo6u
-      "@nrwl/workspace": 15.0.5_7p4kftbl4xdiv7pp73ecrv754e
+      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.9.3
+      "@nrwl/js": 15.0.5_qatfe6ntf4fdpsyekfwphhseru
+      "@nrwl/workspace": 15.0.5_mqtuwqoshjopmdjnatemz7t4rq
       autoprefixer: 10.4.13_postcss@8.4.18
       babel-loader: 8.3.0_hkczypimj4evef4hfazf6yfxte
       browserslist: 4.21.4
@@ -4138,7 +4138,7 @@ packages:
       css-minimizer-webpack-plugin: 3.4.1_webpack@5.74.0
       dotenv: 10.0.0
       file-loader: 6.2.0_webpack@5.74.0
-      fork-ts-checker-webpack-plugin: 7.2.13_qqxisngxjbp7lstdk7boexbu3e
+      fork-ts-checker-webpack-plugin: 7.2.13_ioost42n2pkm3q6vbnx4ypyu7a
       fs-extra: 10.1.0
       ignore: 5.2.0
       less: 3.12.2
@@ -4160,8 +4160,8 @@ packages:
       stylus: 0.55.0
       stylus-loader: 6.2.0_772wava6yveehcyvgfd527qm3q
       terser-webpack-plugin: 5.3.6_webpack@5.74.0
-      ts-loader: 9.4.1_qqxisngxjbp7lstdk7boexbu3e
-      ts-node: 10.9.1_2cnt46lw4tdywdelgueo3bh3pq
+      ts-loader: 9.4.1_ioost42n2pkm3q6vbnx4ypyu7a
+      ts-node: 10.9.1_qlbucxx4nxy66tcqp4burcab4y
       tsconfig-paths: 3.14.1
       tsconfig-paths-webpack-plugin: 3.5.2
       tslib: 2.4.1
@@ -4199,7 +4199,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@nrwl/workspace/15.0.5_7p4kftbl4xdiv7pp73ecrv754e:
+  /@nrwl/workspace/15.0.5_mqtuwqoshjopmdjnatemz7t4rq:
     resolution:
       {
         integrity: sha512-VDMPAv8zgU4MhQy/dSx/aVQumoi2sIpNlQX+qittCeb1T3PADzliGHOSDcCAXQoyXErl4jfyibZQioPcGJAQ9A==,
@@ -4210,9 +4210,9 @@ packages:
       prettier:
         optional: true
     dependencies:
-      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.8.4
-      "@nrwl/jest": 15.0.5_mzmvppv532gkqhi7ksj56p73cq
-      "@nrwl/linter": 15.0.5_6bvy3djy6esm64tr6fz4cuweme
+      "@nrwl/devkit": 15.0.5_nx@15.0.5+typescript@4.9.3
+      "@nrwl/jest": 15.0.5_trx2rcki53waib6i65up2uwqby
+      "@nrwl/linter": 15.0.5_vio6jx45e2tgkhx5vlhesjga34
       "@parcel/watcher": 2.0.4
       chalk: 4.1.0
       chokidar: 3.5.3
@@ -4466,7 +4466,7 @@ packages:
       node-gyp-build: 4.5.0
     dev: true
 
-  /@phenomnomnominal/tsquery/4.1.1_typescript@4.8.4:
+  /@phenomnomnominal/tsquery/4.1.1_typescript@4.9.3:
     resolution:
       {
         integrity: sha512-jjMmK1tnZbm1Jq5a7fBliM4gQwjxMU7TFoRNwIyzwlO+eHPRCFv/Nv+H/Gi1jc3WR7QURG8D5d0Tn12YGrUqBQ==,
@@ -4475,7 +4475,7 @@ packages:
       typescript: ^3 || ^4
     dependencies:
       esquery: 1.4.0
-      typescript: 4.8.4
+      typescript: 4.9.3
     dev: true
 
   /@playwright/test/1.27.1:
@@ -5715,7 +5715,7 @@ packages:
     dev: false
     optional: true
 
-  /@typescript-eslint/eslint-plugin/5.42.1_edj3z5fb2d4dyl4qibv6szemjm:
+  /@typescript-eslint/eslint-plugin/5.42.1_er2pzvpk327s27wxfnvf7drdoy:
     resolution:
       {
         integrity: sha512-LyR6x784JCiJ1j6sH5Y0K6cdExqCCm8DJUTcwG5ThNXJj/G8o5E56u5EdG4SLy+bZAwZBswC+GYn3eGdttBVCg==,
@@ -5729,23 +5729,23 @@ packages:
       typescript:
         optional: true
     dependencies:
-      "@typescript-eslint/parser": 5.42.1_oy7hgmlo6357d5kkcjbkfgtg4q
+      "@typescript-eslint/parser": 5.42.1_wdqgoy3juh7r2u2b4n4o4ol5rq
       "@typescript-eslint/scope-manager": 5.42.1
-      "@typescript-eslint/type-utils": 5.42.1_oy7hgmlo6357d5kkcjbkfgtg4q
-      "@typescript-eslint/utils": 5.42.1_oy7hgmlo6357d5kkcjbkfgtg4q
+      "@typescript-eslint/type-utils": 5.42.1_wdqgoy3juh7r2u2b4n4o4ol5rq
+      "@typescript-eslint/utils": 5.42.1_wdqgoy3juh7r2u2b4n4o4ol5rq
       debug: 4.3.4
       eslint: 8.15.0
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      tsutils: 3.21.0_typescript@4.9.3
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.42.1_oy7hgmlo6357d5kkcjbkfgtg4q:
+  /@typescript-eslint/parser/5.42.1_wdqgoy3juh7r2u2b4n4o4ol5rq:
     resolution:
       {
         integrity: sha512-kAV+NiNBWVQDY9gDJDToTE/NO8BHi4f6b7zTsVAJoTkmB/zlfOpiEVBzHOKtlgTndCKe8vj9F/PuolemZSh50Q==,
@@ -5760,10 +5760,10 @@ packages:
     dependencies:
       "@typescript-eslint/scope-manager": 5.42.1
       "@typescript-eslint/types": 5.42.1
-      "@typescript-eslint/typescript-estree": 5.42.1_typescript@4.8.4
+      "@typescript-eslint/typescript-estree": 5.42.1_typescript@4.9.3
       debug: 4.3.4
       eslint: 8.15.0
-      typescript: 4.8.4
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5779,7 +5779,7 @@ packages:
       "@typescript-eslint/visitor-keys": 5.42.1
     dev: true
 
-  /@typescript-eslint/type-utils/5.42.1_oy7hgmlo6357d5kkcjbkfgtg4q:
+  /@typescript-eslint/type-utils/5.42.1_wdqgoy3juh7r2u2b4n4o4ol5rq:
     resolution:
       {
         integrity: sha512-WWiMChneex5w4xPIX56SSnQQo0tEOy5ZV2dqmj8Z371LJ0E+aymWD25JQ/l4FOuuX+Q49A7pzh/CGIQflxMVXg==,
@@ -5792,12 +5792,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      "@typescript-eslint/typescript-estree": 5.42.1_typescript@4.8.4
-      "@typescript-eslint/utils": 5.42.1_oy7hgmlo6357d5kkcjbkfgtg4q
+      "@typescript-eslint/typescript-estree": 5.42.1_typescript@4.9.3
+      "@typescript-eslint/utils": 5.42.1_wdqgoy3juh7r2u2b4n4o4ol5rq
       debug: 4.3.4
       eslint: 8.15.0
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      tsutils: 3.21.0_typescript@4.9.3
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5810,7 +5810,7 @@ packages:
     engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.42.1_typescript@4.8.4:
+  /@typescript-eslint/typescript-estree/5.42.1_typescript@4.9.3:
     resolution:
       {
         integrity: sha512-qElc0bDOuO0B8wDhhW4mYVgi/LZL+igPwXtV87n69/kYC/7NG3MES0jHxJNCr4EP7kY1XVsRy8C/u3DYeTKQmw==,
@@ -5828,13 +5828,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      tsutils: 3.21.0_typescript@4.9.3
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.42.1_oy7hgmlo6357d5kkcjbkfgtg4q:
+  /@typescript-eslint/utils/5.42.1_wdqgoy3juh7r2u2b4n4o4ol5rq:
     resolution:
       {
         integrity: sha512-Gxvf12xSp3iYZd/fLqiQRD4uKZjDNR01bQ+j8zvhPjpsZ4HmvEFL/tC4amGNyxN9Rq+iqvpHLhlqx6KTxz9ZyQ==,
@@ -5847,7 +5847,7 @@ packages:
       "@types/semver": 7.3.13
       "@typescript-eslint/scope-manager": 5.42.1
       "@typescript-eslint/types": 5.42.1
-      "@typescript-eslint/typescript-estree": 5.42.1_typescript@4.8.4
+      "@typescript-eslint/typescript-estree": 5.42.1_typescript@4.9.3
       eslint: 8.15.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.15.0
@@ -9893,7 +9893,7 @@ packages:
     optionalDependencies:
       source-map: 0.6.1
 
-  /eslint-config-next/13.0.0_oy7hgmlo6357d5kkcjbkfgtg4q:
+  /eslint-config-next/13.0.0_wdqgoy3juh7r2u2b4n4o4ol5rq:
     resolution:
       {
         integrity: sha512-y2nqWS2tycWySdVhb+rhp6CuDmDazGySqkzzQZf3UTyfHyC7og1m5m/AtMFwCo5mtvDqvw1BENin52kV9733lg==,
@@ -9907,7 +9907,7 @@ packages:
     dependencies:
       "@next/eslint-plugin-next": 13.0.0
       "@rushstack/eslint-patch": 1.2.0
-      "@typescript-eslint/parser": 5.42.1_oy7hgmlo6357d5kkcjbkfgtg4q
+      "@typescript-eslint/parser": 5.42.1_wdqgoy3juh7r2u2b4n4o4ol5rq
       eslint: 8.15.0
       eslint-import-resolver-node: 0.3.6
       eslint-import-resolver-typescript: 2.7.1_gwd37gqv3vjv3xlpl7ju3ag2qu
@@ -9915,7 +9915,7 @@ packages:
       eslint-plugin-jsx-a11y: 6.6.1_eslint@8.15.0
       eslint-plugin-react: 7.31.8_eslint@8.15.0
       eslint-plugin-react-hooks: 4.6.0_eslint@8.15.0
-      typescript: 4.8.4
+      typescript: 4.9.3
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
@@ -9990,7 +9990,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      "@typescript-eslint/parser": 5.42.1_oy7hgmlo6357d5kkcjbkfgtg4q
+      "@typescript-eslint/parser": 5.42.1_wdqgoy3juh7r2u2b4n4o4ol5rq
       debug: 3.2.7
       eslint: 8.15.0
       eslint-import-resolver-node: 0.3.6
@@ -10022,7 +10022,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      "@typescript-eslint/parser": 5.42.1_oy7hgmlo6357d5kkcjbkfgtg4q
+      "@typescript-eslint/parser": 5.42.1_wdqgoy3juh7r2u2b4n4o4ol5rq
       debug: 3.2.7
       eslint: 8.15.0
       eslint-import-resolver-node: 0.3.6
@@ -10044,7 +10044,7 @@ packages:
       "@typescript-eslint/parser":
         optional: true
     dependencies:
-      "@typescript-eslint/parser": 5.42.1_oy7hgmlo6357d5kkcjbkfgtg4q
+      "@typescript-eslint/parser": 5.42.1_wdqgoy3juh7r2u2b4n4o4ol5rq
       array-includes: 3.1.5
       array.prototype.flat: 1.3.1
       debug: 2.6.9
@@ -10078,7 +10078,7 @@ packages:
       "@typescript-eslint/parser":
         optional: true
     dependencies:
-      "@typescript-eslint/parser": 5.42.1_oy7hgmlo6357d5kkcjbkfgtg4q
+      "@typescript-eslint/parser": 5.42.1_wdqgoy3juh7r2u2b4n4o4ol5rq
       array-includes: 3.1.5
       array.prototype.flat: 1.3.1
       debug: 2.6.9
@@ -10902,7 +10902,7 @@ packages:
       is-callable: 1.2.7
     dev: true
 
-  /fork-ts-checker-webpack-plugin/7.2.13_qqxisngxjbp7lstdk7boexbu3e:
+  /fork-ts-checker-webpack-plugin/7.2.13_ioost42n2pkm3q6vbnx4ypyu7a:
     resolution:
       {
         integrity: sha512-fR3WRkOb4bQdWB/y7ssDUlVdrclvwtyCUIHCfivAoYxq9dF7XfrDKbMdZIfwJ7hxIAqkYSGeU7lLJE6xrxIBdg==,
@@ -10928,7 +10928,7 @@ packages:
       schema-utils: 3.1.1
       semver: 7.3.8
       tapable: 2.2.1
-      typescript: 4.8.4
+      typescript: 4.9.3
       webpack: 5.74.0
     dev: true
 
@@ -12749,7 +12749,7 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_2cnt46lw4tdywdelgueo3bh3pq
+      ts-node: 10.9.1_qlbucxx4nxy66tcqp4burcab4y
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12792,7 +12792,7 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_2cnt46lw4tdywdelgueo3bh3pq
+      ts-node: 10.9.1_qlbucxx4nxy66tcqp4burcab4y
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -16463,7 +16463,7 @@ packages:
     dependencies:
       lilconfig: 2.0.6
       postcss: 8.4.18
-      ts-node: 10.9.1_2cnt46lw4tdywdelgueo3bh3pq
+      ts-node: 10.9.1_qlbucxx4nxy66tcqp4burcab4y
       yaml: 1.10.2
     dev: true
 
@@ -17618,10 +17618,10 @@ packages:
       unified: 10.1.2
     dev: false
 
-  /remark-callouts/1.0.2:
+  /remark-callouts/2.0.0:
     resolution:
       {
-        integrity: sha512-c29i32l++jUmh/Ol3s6s/UMer2gk02/jTitbjcxPY9RFShXE7XjK9cOmZfMeFMgz/TWH1iP3YeeB4ttTzjTLDg==,
+        integrity: sha512-kTtBca6NzVNVn71wKMBiliSS/XEtYr6CQgWFQt+s6lkqtHHwHsfP4PxsqFbL98m9nxqlnqTyoYfNr1//u9jrlA==,
       }
     dependencies:
       mdast-util-from-markdown: 1.2.0
@@ -18063,7 +18063,7 @@ packages:
       - ts-node
     dev: true
 
-  /rollup-plugin-typescript2/0.31.2_gypgyaqhine6mwjfvh7icfhviq:
+  /rollup-plugin-typescript2/0.31.2_k35zwyycrckt5xfsejji7kbwn4:
     resolution:
       {
         integrity: sha512-hRwEYR1C8xDGVVMFJQdEVnNAeWRvpaY97g5mp3IeLnzhNXzSVq78Ye/BJ9PAaUfN4DXa/uDnqerifMOaMFY54Q==,
@@ -18079,7 +18079,7 @@ packages:
       resolve: 1.22.1
       rollup: 2.79.1
       tslib: 2.4.1
-      typescript: 4.8.4
+      typescript: 4.9.3
     dev: true
 
   /rollup-pluginutils/2.8.2:
@@ -19557,7 +19557,7 @@ packages:
       }
     dev: false
 
-  /ts-jest/28.0.5_pfatmudpkfer4fk26itqij7pwu:
+  /ts-jest/28.0.5_tinkr55cgdkjhd4ukaexa5wwju:
     resolution:
       {
         integrity: sha512-Sx9FyP9pCY7pUzQpy4FgRZf2bhHY3za576HMKJFs+OnQ9jS96Du5vNsDKkyedQkik+sEabbKAnCliv9BEsHZgQ==,
@@ -19588,11 +19588,11 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.3.8
-      typescript: 4.8.4
+      typescript: 4.9.3
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-loader/9.4.1_qqxisngxjbp7lstdk7boexbu3e:
+  /ts-loader/9.4.1_ioost42n2pkm3q6vbnx4ypyu7a:
     resolution:
       {
         integrity: sha512-384TYAqGs70rn9F0VBnh6BPTfhga7yFNdC5gXbQpDrBj9/KsT4iRkGqKXhziofHOlE2j6YEaiTYVGKKvPhGWvw==,
@@ -19606,11 +19606,11 @@ packages:
       enhanced-resolve: 5.10.0
       micromatch: 4.0.5
       semver: 7.3.4
-      typescript: 4.8.4
+      typescript: 4.9.3
       webpack: 5.74.0
     dev: true
 
-  /ts-node/10.9.1_2cnt46lw4tdywdelgueo3bh3pq:
+  /ts-node/10.9.1_qlbucxx4nxy66tcqp4burcab4y:
     resolution:
       {
         integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==,
@@ -19639,7 +19639,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.8.4
+      typescript: 4.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -19687,7 +19687,7 @@ packages:
         integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==,
       }
 
-  /tsutils/3.21.0_typescript@4.8.4:
+  /tsutils/3.21.0_typescript@4.9.3:
     resolution:
       {
         integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==,
@@ -19697,7 +19697,7 @@ packages:
       typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
     dependencies:
       tslib: 1.14.1
-      typescript: 4.8.4
+      typescript: 4.9.3
     dev: true
 
   /tty-table/4.1.6:
@@ -19815,15 +19815,6 @@ packages:
       {
         integrity: sha512-KNNZtayBCtmnNmbo5mG47p1XsCyrx6iVqomjcZnec/1Y5GGARaxPs6r49RnSPeUP3YjNYiU9sQHAtY4BBvnZwg==,
       }
-    dev: true
-
-  /typescript/4.8.4:
-    resolution:
-      {
-        integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==,
-      }
-    engines: { node: ">=4.2.0" }
-    hasBin: true
     dev: true
 
   /typescript/4.9.3:


### PR DESCRIPTION
### Summary
Issue related to comments from #253 

This PR bumps the remark-callouts plugin to v2.0.0 with latest changes and adds callout styles.

### Changes

* Bump `remark-callouts` to v2.0.0 in `package.json`
* Add callout styles in `styles/global.css` - `@import "remark-callouts/styles.css`
* pnpm lock file update