### PR TITLE
Update remark-callouts and import styles

### DIFF
--- a/packages/template/package-lock.json
+++ b/packages/template/package-lock.json
@@ -30,7 +30,7 @@
         "rehype-mathjax": "^4.0.2",
         "rehype-prism-plus": "^1.4.2",
         "rehype-slug": "^5.0.1",
-        "remark-callouts": "^1.0.2",
+        "remark-callouts": "^2.0.0",
         "remark-code-extra": "^1.0.1",
         "remark-embed-plus": "^1.0.2",
         "remark-gfm": "^3.0.0",
@@ -6575,9 +6575,9 @@
       }
     },
     "node_modules/remark-callouts": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/remark-callouts/-/remark-callouts-1.0.2.tgz",
-      "integrity": "sha512-c29i32l++jUmh/Ol3s6s/UMer2gk02/jTitbjcxPY9RFShXE7XjK9cOmZfMeFMgz/TWH1iP3YeeB4ttTzjTLDg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/remark-callouts/-/remark-callouts-2.0.0.tgz",
+      "integrity": "sha512-kTtBca6NzVNVn71wKMBiliSS/XEtYr6CQgWFQt+s6lkqtHHwHsfP4PxsqFbL98m9nxqlnqTyoYfNr1//u9jrlA==",
       "dependencies": {
         "mdast-util-from-markdown": "^1.2.0",
         "svg-parser": "^2.0.4",
@@ -12737,9 +12737,9 @@
       }
     },
     "remark-callouts": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/remark-callouts/-/remark-callouts-1.0.2.tgz",
-      "integrity": "sha512-c29i32l++jUmh/Ol3s6s/UMer2gk02/jTitbjcxPY9RFShXE7XjK9cOmZfMeFMgz/TWH1iP3YeeB4ttTzjTLDg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/remark-callouts/-/remark-callouts-2.0.0.tgz",
+      "integrity": "sha512-kTtBca6NzVNVn71wKMBiliSS/XEtYr6CQgWFQt+s6lkqtHHwHsfP4PxsqFbL98m9nxqlnqTyoYfNr1//u9jrlA==",
       "requires": {
         "mdast-util-from-markdown": "^1.2.0",
         "svg-parser": "^2.0.4",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -32,7 +32,7 @@
     "rehype-mathjax": "^4.0.2",
     "rehype-prism-plus": "^1.4.2",
     "rehype-slug": "^5.0.1",
-    "remark-callouts": "^1.0.2",
+    "remark-callouts": "^2.0.0",
     "remark-code-extra": "^1.0.1",
     "remark-embed-plus": "^1.0.2",
     "remark-gfm": "^3.0.0",

--- a/packages/template/styles/global.css
+++ b/packages/template/styles/global.css
@@ -1,3 +1,5 @@
+@import "remark-callouts/styles.css";
+
 /* mathjax */
 .math-inline {
   display: flex;


### PR DESCRIPTION
### Summary

This PR updates the remark-callouts plugin to v2.0.0 that includes changes to how styles are handled.

### Changes

* Bump `remark-callouts` to `v2.0.0`
* import styles in `styles/global.css` - `@import "remark-callouts/styles.css"`