### PR TITLE
Export and symlink Excalidraw images

### DIFF
--- a/packages/template/public/excalidraw
+++ b/packages/template/public/excalidraw
@@ -1,0 +1,1 @@
+../content/excalidraw

--- a/site/content/assets/images/docs-excalidraw-images-1.png
+++ b/site/content/assets/images/docs-excalidraw-images-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96ae8ddece4bf0e88422b1a4d060d00e8ea6009ceaae506c172f555ba37d79c4
+size 87402

--- a/site/content/assets/images/docs-excalidraw-images-2.png
+++ b/site/content/assets/images/docs-excalidraw-images-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10acb371b4c3c333182d8a973f5f5ff9c478fef539f54119d7fc82eff4c84e24
+size 445601

--- a/site/content/assets/images/docs-excalidraw-images-3.png
+++ b/site/content/assets/images/docs-excalidraw-images-3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c5df6205d048ef729a5d2290d274d8a288b365fd0535f67fd52ee1e6c4a36f4
+size 76424

--- a/site/content/docs/excalidraw.md
+++ b/site/content/docs/excalidraw.md
@@ -1,0 +1,26 @@
+# Excalidraw support in flowershow
+
+Flowershow supports displaying your excalidraw images on your site.
+
+## Auto generating Excalidraw images
+
+In Obsidian you can use the excalidraw plugin to auto generate images next to it's relevant file.
+
+_Assuming that you have this plugin installed ..._
+
+Head over to the excalidraw plugin in Obsidian settings and make sure you have the following setup configured.
+
+1. Configure the plugin to export svg or png
+
+![[docs-excalidraw-images-1.png]]
+Note that you can choose png or svg ...
+
+![[docs-excalidraw-images-2.png]] 2. Make sure you have a defined folder for your excalidraw files.
+
+![[docs-excalidraw-images-3.png]]
+Symlink this directory into public folder in flowershow.
+
+```bash=
+$ cd <your-flowershow-directory>
+$ ln -s content/excalidraw/ site/public/
+```


### PR DESCRIPTION
### Summary
Closes #10 

This PR symlinks the excalidraw folder in public and adds docs for configuring Excalidraw images in Obsidian.

### Changes

- Symlink excalidraw folder in `packages/template` ie. `content/excalidraw -->  public/excalidraw`
- Add docs for exporting excalidraw png or svg in Obsidian and symlink the folder @ [docs/excalidraw](https://deploy-preview-349--spectacular-dragon-c1015c.netlify.app/docs/excalidraw)