### PR TITLE
[content][s]: documentation for link preview tooltips

### DIFF
--- a/site/content/assets/images/link-preview-with-image.jpg
+++ b/site/content/assets/images/link-preview-with-image.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa49ca726b38d4471a989b952a0877d27dd6ffacfed984228fb7e35b883c9751
+size 39044

--- a/site/content/assets/images/link-preview.jpg
+++ b/site/content/assets/images/link-preview.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b5bc151a81d624852bd5646069413c6c4cdaed2ee1dc2d976ff950bfd03a02d
+size 46802

--- a/site/content/docs/link-previews.md
+++ b/site/content/docs/link-previews.md
@@ -1,0 +1,24 @@
+---
+title: Link Preview Tooltips
+---
+
+Flowershow supports showing tooltips with the page's preview content when hovering over links to other documents within your site.
+
+> [!note]
+> Tooltips are only supported for internal links ie. links to other pages within your site and not for external links eg. `https://someOtherSite.com/`
+
+After hovering over a link, the tooltip will be displayed as seen in the screenshot below:
+![[link-preview.jpg]]
+
+If your page has an image in the frontmatter, the image will also be displayed in the following style
+![[link-preview-with-image.jpg]]
+
+This feature is enabled by default and if not required, it can be toggled off by setting the `linkPreviews` variable to false in your `config.js` file.
+
+```js
+// config.js
+
+const config = {
+  linkPreviews: false,
+};
+```


### PR DESCRIPTION
### Summary
Tasks from #36 

This PR adds documentation about link preview tooltips on hover and how to disable them in `config.js`

### Changes
* Add docs page at [docs/link-previews](docs/link-previews)
* Add screenshot images