### PR TITLE
Default fonts in tailwind

### DIFF
--- a/packages/template/layouts/blog.jsx
+++ b/packages/template/layouts/blog.jsx
@@ -6,7 +6,7 @@ export default function BlogLayout({ children, frontMatter }) {
   const { title, created, authorsDetails } = frontMatter;
 
   return (
-    <article className="docs prose dark:prose-invert prose-a:break-words mx-auto p-6">
+    <article className="docs prose prose-headings:font-headings dark:prose-invert prose-a:break-words mx-auto p-6">
       <header>
         <div className="mb-4 flex-col items-center">
           {title && <h1 className="flex justify-center">{title}</h1>}

--- a/packages/template/layouts/docs.jsx
+++ b/packages/template/layouts/docs.jsx
@@ -4,7 +4,7 @@ import { formatDate } from "@/lib/formatDate.js";
 export default function DocsLayout({ children, frontMatter }) {
   const { title, created } = frontMatter;
   return (
-    <article className="docs prose dark:prose-invert prose-a:break-words mx-auto p-6">
+    <article className="docs prose dark:prose-invert prose-headings:font-headings prose-a:break-words mx-auto p-6">
       <header>
         <div className="mb-6">
           {created && (

--- a/packages/template/tailwind.config.js
+++ b/packages/template/tailwind.config.js
@@ -1,3 +1,5 @@
+const defaultTheme = require("tailwindcss/defaultTheme");
+
 module.exports = {
   content: [
     "./pages/**/*.{js,ts,jsx,tsx}",
@@ -11,6 +13,12 @@ module.exports = {
       // support wider width for large screens >1440px eg. in hero
       maxWidth: {
         "8xl": "88rem",
+      },
+      fontFamily: {
+        sans: ["ui-sans-serif", ...defaultTheme.fontFamily.sans],
+        serif: ["ui-serif", ...defaultTheme.fontFamily.serif],
+        mono: ["ui-monospace", ...defaultTheme.fontFamily.mono],
+        headings: ["-apple-system", ...defaultTheme.fontFamily.sans],
       },
     },
   },


### PR DESCRIPTION
### Summary
Tasks from #351 

This PR adds tailwind's default fonts and a heading font for easy configuration and use in layouts or components.

### Changes
* Overwrite `tailwind.config.js` with tailwind's default fonts
  * Add a custom `font-headings` property for headings
* Use semantic heading fonts in layouts