### PR TITLE
Allow installing as non-admin on Windows

### DIFF
--- a/packages/cli/src/bin/cli.ts
+++ b/packages/cli/src/bin/cli.ts
@@ -14,7 +14,7 @@ const { version: node, platform, argv } = process;
 
 if (platform === "win32") {
   warn(
-    "This may not work as expected. You're trying to run Flowreshow CLI on Windows, which is not thoroughly tested. Please submit an issue if you encounter any problems: https://github.com/flowershow/flowershow/issues"
+    "This may not work as expected. You're trying to run Flowershow CLI on Windows, which is not thoroughly tested. Please submit an issue if you encounter any problems: https://github.com/flowershow/flowershow/issues"
   );
 }
 

--- a/packages/cli/src/lib/Installer.ts
+++ b/packages/cli/src/lib/Installer.ts
@@ -194,7 +194,7 @@ export default class Installer {
 
     // update content and assets symlinks
     const contentSymlinkPath = path.relative(`${flowershowDir}`, contentDir);
-    fs.symlinkSync(contentSymlinkPath, `${flowershowDir}/content`);
+    fs.symlinkSync(contentSymlinkPath, `${flowershowDir}/content`, 'junction');
 
     if (assetsFolder !== "none") {
       const assetsSymlinkPath = path.relative(
@@ -203,7 +203,8 @@ export default class Installer {
       );
       fs.symlinkSync(
         assetsSymlinkPath,
-        `${flowershowDir}/public/${assetsFolder}`
+        `${flowershowDir}/public/${assetsFolder}`,
+        'junction'
       );
     }
 

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "postbuild": "cross-env NODE_OPTIONS='--experimental-json-modules --experimental-modules' node ./scripts/search.mjs",
+    "postbuild": "cross-env NODE_OPTIONS=\"--experimental-json-modules --experimental-modules\" node ./scripts/search.mjs",
     "start": "next start",
     "export": "npm run build && next export"
   },

--- a/scripts/symlink-site.js
+++ b/scripts/symlink-site.js
@@ -14,17 +14,17 @@ const excalidrawSymlink = "../packages/template/public/excalidraw";
 const componentsSymlink = "../packages/template/components/custom";
 
 if (!fs.existsSync(contentSymlink)) {
-  fs.symlinkSync("../../site/content", contentSymlink);
+  fs.symlinkSync("../../site/content", contentSymlink, 'junction');
 }
 
 if (!fs.existsSync(assetsSymlink)) {
-  fs.symlinkSync("../../../site/content/assets", assetsSymlink);
+  fs.symlinkSync("../../../site/content/assets", assetsSymlink, 'junction');
 }
 
 if (!fs.existsSync(excalidrawSymlink)) {
-  fs.symlinkSync("../../../site/content/excalidraw", excalidrawSymlink);
+  fs.symlinkSync("../../../site/content/excalidraw", excalidrawSymlink, 'junction');
 }
 
 if (!fs.existsSync(componentsSymlink)) {
-  fs.symlinkSync("../../../site/components", componentsSymlink);
+  fs.symlinkSync("../../../site/components", componentsSymlink, 'junction');
 }


### PR DESCRIPTION
Fixes a minor typo and passes the `type` parameter to [`fs.symlinkSync`](https://nodejs.org/api/fs.html#fssymlinktarget-path-type-callback) (which is used only on Windows and ignored on others) to remove the need to run as admin.