### PR TITLE
Link previews on hover

### DIFF
--- a/.changeset/loud-hairs-attend.md
+++ b/.changeset/loud-hairs-attend.md
@@ -1,0 +1,6 @@
+---
+"@flowershow/template": minor
+"@flowershow/core": minor
+---
+
+Add new feature to show previews for internal pages on hovering over it's link along with updated documentation.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
   "main": "./dist/index.js",
   "dependencies": {
     "@docsearch/react": "^3.3.0",
+    "@floating-ui/react-dom": "^1.2.1",
     "@floating-ui/react-dom-interactions": "^0.13.3",
     "@headlessui/react": "^1.7.6",
     "clsx": "^1.2.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,8 +20,10 @@
   "main": "./dist/index.js",
   "dependencies": {
     "@docsearch/react": "^3.3.0",
+    "@floating-ui/react-dom-interactions": "^0.13.3",
     "@headlessui/react": "^1.7.6",
     "clsx": "^1.2.1",
+    "framer-motion": "^8.4.3",
     "kbar": "0.1.0-beta.39",
     "mdx-mermaid": "^1.3.2",
     "mermaid": "^9.3.0"

--- a/packages/core/src/config/default.js
+++ b/packages/core/src/config/default.js
@@ -3,6 +3,7 @@ export const defaultConfig = {
   description: "",
   showEditLink: false,
   showToc: true,
+  showLinkPreviews: true,
   author: "",
   authorLogo: "",
   authorUrl: "",

--- a/packages/core/src/ui/Base/CustomLink.tsx
+++ b/packages/core/src/ui/Base/CustomLink.tsx
@@ -15,7 +15,7 @@ export const CustomLink: React.FC<Props> = ({
   preview,
   ...props
 }) => {
-  const { href } = props;
+  const { href } = props; // keep href in props to render tooltip content
   const isInternalLink = href && href.startsWith("/");
   const isAnchorLink = href && href.startsWith("#");
 

--- a/packages/core/src/ui/Base/CustomLink.tsx
+++ b/packages/core/src/ui/Base/CustomLink.tsx
@@ -1,33 +1,28 @@
 import Link from "next/link.js";
 import { Tooltip } from "../Tooltip";
 
-type Config = {
-  showLinkPreviews: boolean;
-};
-
 interface Props {
   href?: string;
   data: any;
   usehook: any;
-  config: Config;
+  preview: boolean;
   [x: string]: unknown;
 }
 
 export const CustomLink: React.FC<Props> = ({
-  config,
   data,
   usehook,
+  preview,
   ...props
 }) => {
   const { href } = props;
   const isInternalLink = href && href.startsWith("/");
   const isAnchorLink = href && href.startsWith("#");
 
-  // TODO why are we doing this?
   // Use next link for pages within app and <a> for external links.
   // https://nextjs.org/learn/basics/navigate-between-pages/client-side
   if (isInternalLink) {
-    return config.showLinkPreviews ? (
+    return preview ? (
       <Tooltip
         {...props}
         data={data}

--- a/packages/core/src/ui/Base/CustomLink.tsx
+++ b/packages/core/src/ui/Base/CustomLink.tsx
@@ -1,22 +1,47 @@
 import Link from "next/link.js";
+import { Tooltip } from "../Tooltip";
+
+type Config = {
+  showLinkPreviews: boolean;
+};
 
 interface Props {
   href?: string;
+  data: any;
+  usehook: any;
+  config: Config;
   [x: string]: unknown;
 }
 
-export const CustomLink: React.FC<Props> = ({ href, ...rest }) => {
+export const CustomLink: React.FC<Props> = ({
+  config,
+  data,
+  usehook,
+  ...props
+}) => {
+  const { href } = props;
   const isInternalLink = href && href.startsWith("/");
   const isAnchorLink = href && href.startsWith("#");
 
   // TODO why are we doing this?
+  // Use next link for pages within app and <a> for external links.
+  // https://nextjs.org/learn/basics/navigate-between-pages/client-side
   if (isInternalLink) {
-    return <Link href={href} {...rest} />;
+    return config.showLinkPreviews ? (
+      <Tooltip
+        {...props}
+        data={data}
+        usehook={usehook}
+        render={(tooltipTriggerProps) => <Link {...tooltipTriggerProps} />}
+      />
+    ) : (
+      <Link href={href} {...props} />
+    );
   }
 
   if (isAnchorLink) {
-    return <a href={href} {...rest} />;
+    return <a {...props} />;
   }
 
-  return <a target="_blank" rel="noopener noreferrer" href={href} {...rest} />;
+  return <a target="_blank" rel="noopener noreferrer" {...props} />;
 };

--- a/packages/core/src/ui/Tooltip/Tooltip.tsx
+++ b/packages/core/src/ui/Tooltip/Tooltip.tsx
@@ -1,11 +1,16 @@
 import React, { useState, useEffect, useRef, Fragment } from "react";
 
+// importing separately due to build error
+// Module '"@floating-ui/react-dom-interactions"' has no exported member 'autoPlacement' ...
 import {
   arrow,
   autoPlacement,
   inline,
   offset,
   shift,
+} from "@floating-ui/react-dom";
+
+import {
   FloatingPortal,
   useDismiss,
   useFloating,

--- a/packages/core/src/ui/Tooltip/Tooltip.tsx
+++ b/packages/core/src/ui/Tooltip/Tooltip.tsx
@@ -1,0 +1,221 @@
+import React, { useState, useEffect, useRef, Fragment } from "react";
+
+import {
+  arrow,
+  autoPlacement,
+  inline,
+  offset,
+  shift,
+  FloatingPortal,
+  useDismiss,
+  useFloating,
+  useHover,
+  useFocus,
+  useInteractions,
+  useRole,
+} from "@floating-ui/react-dom-interactions";
+
+import { motion, AnimatePresence } from "framer-motion";
+
+interface Props extends React.PropsWithChildren {
+  render?: (t) => React.ReactNode;
+  href?: string;
+  data: any;
+  usehook?: any;
+  className?: string;
+}
+
+const tooltipBoxStyle = (theme: string) =>
+  ({
+    height: "auto",
+    maxWidth: "40rem",
+    padding: "1rem",
+    background: theme === "light" ? "#fff" : "#000",
+    color: theme === "light" ? "rgb(99, 98, 98)" : "#A8A8A8",
+    borderRadius: "4px",
+    boxShadow: "rgba(0, 0, 0, 0.55) 0px 0px 16px -3px",
+  } as React.CSSProperties);
+
+const tooltipBodyStyle = (theme: string) =>
+  ({
+    maxHeight: "4.8rem",
+    position: "relative",
+    lineHeight: "1.2rem",
+    overflow: "hidden",
+  } as React.CSSProperties);
+
+const tooltipArrowStyle = ({ theme, x, y, side }) =>
+  ({
+    position: "absolute",
+    left: x != null ? `${x}px` : "",
+    top: y != null ? `${y}px` : "",
+    right: "",
+    bottom: "",
+    [side]: "-4px",
+    height: "8px",
+    width: "8px",
+    background: theme === "light" ? "#fff" : "#000",
+    transform: "rotate(45deg)",
+  } as React.CSSProperties);
+
+export const Tooltip: React.FC<Props> = ({
+  render,
+  data,
+  usehook,
+  ...props
+}) => {
+  const theme = "light"; // temporarily hard-coded; light theme tbd in next PR
+
+  const arrowRef = useRef(null);
+  const [showTooltip, setShowTooltip] = useState(false);
+  const [tooltipData, setTooltipData] = useState({
+    content: <Fragment />,
+    image: "",
+  });
+  const [tooltipContentLoaded, setTooltipContentLoaded] = useState(false);
+  // floating-ui hook
+  const {
+    x,
+    y,
+    reference, // trigger element back ref
+    floating, // tooltip back ref
+    placement, // default: 'bottom'
+    strategy, // default: 'absolute'
+    context,
+    middlewareData: { arrow: { x: arrowX = 0, y: arrowY = 0 } = {} }, // data for arrow positioning
+  } = useFloating({
+    open: showTooltip, // state value binding
+    onOpenChange: setShowTooltip, // state value setter
+    middleware: [
+      offset(5), // offset from container border
+      autoPlacement({ padding: 5 }), // auto place vertically
+      shift({ padding: 5 }), // flip horizontally if necessary
+      arrow({ element: arrowRef, padding: 4 }), // add arrow element
+      inline(), // correct position for multiline anchor tags
+    ],
+  });
+  // floating-ui hook
+  const { getReferenceProps, getFloatingProps } = useInteractions([
+    useHover(context, { delay: 100 }),
+    useFocus(context),
+    useRole(context, { role: "tooltip" }),
+    useDismiss(context, { ancestorScroll: true }),
+  ]);
+
+  const triggerElementProps = getReferenceProps({ ...props, ref: reference });
+  const tooltipProps = getFloatingProps({
+    ref: floating,
+    style: {
+      position: strategy,
+      left: x ?? "",
+      top: y ?? "",
+    },
+  });
+
+  const arrowPlacement = {
+    top: "bottom",
+    right: "left",
+    bottom: "top",
+    left: "right",
+  }[placement.split("-")[0]];
+
+  // get tooltip data
+  let image: string;
+  let PageContent;
+  // create a temporary anchor tag to convert relative href to absolute path
+  const tempLink = document.createElement("a");
+  tempLink.href = props.href as string;
+  const filePath = tempLink.pathname.slice(1); // remove slash from the beginning
+
+  const page = data.find((p) => p._raw.flattenedPath === filePath);
+
+  if (page) {
+    const Component = usehook(page.body.code);
+    PageContent = Component;
+    image = page.image ?? "";
+  }
+
+  const fetchTooltipContent = () => {
+    setTooltipContentLoaded(false);
+
+    let Body: React.ReactElement = <Fragment />;
+
+    // strip out all other elements from tooltip content
+    // since we only need the paragraph
+    const elems = ["h1", "h2", "h3", "div", "img", "pre", "blockquote"].reduce(
+      (acc, elem) => ({ ...acc, [elem]: () => <Fragment /> }),
+      {}
+    );
+
+    if (PageContent) {
+      Body = (
+        <PageContent
+          components={{
+            ...elems,
+            p: (props) => <Fragment {...props} />, // avoid hydration errors
+            wrapper: (props) => <div className="line-clamp-3" {...props} />,
+          }}
+        />
+      );
+    }
+
+    setTooltipData({
+      content: Body,
+      image: image,
+    });
+
+    setTooltipContentLoaded(true);
+  };
+
+  useEffect(() => {
+    if (showTooltip) {
+      fetchTooltipContent();
+    }
+  }, [showTooltip]);
+
+  return (
+    <Fragment>
+      {render?.(triggerElementProps)}
+      <FloatingPortal>
+        <AnimatePresence>
+          {showTooltip && tooltipContentLoaded && (
+            <motion.div
+              {...tooltipProps}
+              initial={{ opacity: 0, scale: 0.85 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ type: "spring", damping: 20, stiffness: 300 }}
+            >
+              <div
+                className="tooltip-box flex items-center space-x-2"
+                style={tooltipBoxStyle(theme)}
+              >
+                {tooltipData.image && (
+                  <img
+                    src={tooltipData.image}
+                    alt=""
+                    width={100}
+                    height={100}
+                  />
+                )}
+                <div className="tooltip-body" style={tooltipBodyStyle(theme)}>
+                  {tooltipData.content}
+                </div>
+              </div>
+              <div
+                ref={arrowRef}
+                className="tooltip-arrow"
+                style={tooltipArrowStyle({
+                  theme,
+                  x: arrowX,
+                  y: arrowY,
+                  side: arrowPlacement,
+                })}
+              ></div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </FloatingPortal>
+    </Fragment>
+  );
+};

--- a/packages/core/src/ui/Tooltip/index.ts
+++ b/packages/core/src/ui/Tooltip/index.ts
@@ -1,0 +1,1 @@
+export { Tooltip } from "./Tooltip";

--- a/packages/template-e2e/src/tests/tooltips.spec.js
+++ b/packages/template-e2e/src/tests/tooltips.spec.js
@@ -1,0 +1,21 @@
+// TODO: Add tooltips test
+
+// const { test, expect } = require("@playwright/test");
+// const { MarkdownPage } = require("../support/markdown-page");
+
+// test.describe.parallel("Link previews on hover", () => {
+//   test.beforeEach(async ({ page }) => {
+//     const Page = new MarkdownPage(page);
+//     await Page.goto("/markdownFeatures");
+//     await Page.getData();
+//   });
+
+//   test("links", async ({ page }) => {
+//     const link = page.locator("#links > p > a");
+//     await expect(link).toContainText("Link to fixture page");
+//     await link.hover()
+//     const tooltipContent = await page.getByRole("tooltip").textContent()
+//     await link.click();
+//     await expect(page).toHaveURL("/fixturepage");
+//   });
+// });

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -16,6 +16,7 @@
     "@flowershow/remark-wiki-link": "^1.0.0",
     "@heroicons/react": "^1.0.4",
     "@silvenon/remark-smartypants": "^1.0.0",
+    "@tailwindcss/line-clamp": "^0.4.2",
     "@tailwindcss/typography": "^0.5.2",
     "contentlayer": "^0.2.8",
     "date-fns": "^2.29.2",

--- a/packages/template/pages/[[...slug]].jsx
+++ b/packages/template/pages/[[...slug]].jsx
@@ -2,6 +2,7 @@
 import { NextSeo } from "next-seo";
 import { allDocuments } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
+import {} from "next-contentlayer/hooks";
 
 import { CustomLink, Pre, BlogsList } from "@flowershow/core";
 
@@ -16,7 +17,14 @@ export default function Page({ globals, body, ...meta }) {
 
   const MDXComponents = {
     /* Head, */ // TODO why do we need this here?
-    a: CustomLink,
+    a: (props) => (
+      <CustomLink
+        data={allDocuments}
+        usehook={useMDXComponent}
+        config={siteConfig}
+        {...props}
+      />
+    ),
     pre: Pre,
     /* eslint no-unused-vars: off */
     // TODO this is a temporary workaround for errors resulting from importing this component directly in mdx file

--- a/packages/template/pages/[[...slug]].jsx
+++ b/packages/template/pages/[[...slug]].jsx
@@ -2,7 +2,6 @@
 import { NextSeo } from "next-seo";
 import { allDocuments } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
-import {} from "next-contentlayer/hooks";
 
 import { CustomLink, Pre, BlogsList } from "@flowershow/core";
 
@@ -21,7 +20,7 @@ export default function Page({ globals, body, ...meta }) {
       <CustomLink
         data={allDocuments}
         usehook={useMDXComponent}
-        config={siteConfig}
+        preview={siteConfig.showLinkPreviews}
         {...props}
       />
     ),

--- a/packages/template/styles/global.css
+++ b/packages/template/styles/global.css
@@ -11,6 +11,21 @@ html {
   scroll-behavior: smooth !important;
 }
 
+/* tooltip fade-out clip */
+.tooltip-body::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  top: 3.6rem; /* multiple of $line-height used on the tooltip body (defined in tooltipBodyStyle) */
+  height: 1.2rem; /* ($top + $height)/$line-height is the number of lines we want to clip tooltip text at*/
+  width: 10rem;
+  background: linear-gradient(
+    to right,
+    rgba(255, 255, 255, 0),
+    rgba(255, 255, 255, 1) 100%
+  );
+}
+
 /* hide anchor link with # icon  */
 .unstyled :is(h1, h2, h3, h4, h5, h6) > a {
   visibility: hidden;

--- a/packages/template/tailwind.config.cjs
+++ b/packages/template/tailwind.config.cjs
@@ -40,5 +40,8 @@ module.exports = {
     },
   },
   /* eslint global-require: off */
-  plugins: [require("@tailwindcss/typography")],
+  plugins: [
+    require("@tailwindcss/typography"),
+    require("@tailwindcss/line-clamp"),
+  ],
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,7 @@ importers:
   packages/core:
     specifiers:
       "@docsearch/react": ^3.3.0
+      "@floating-ui/react-dom": ^1.2.1
       "@floating-ui/react-dom-interactions": ^0.13.3
       "@headlessui/react": ^1.7.6
       clsx: ^1.2.1
@@ -173,6 +174,7 @@ importers:
       react-dom: ^18.0.0
     dependencies:
       "@docsearch/react": 3.3.0_ftygaz6e6e5e4cecsqmsnm4myu
+      "@floating-ui/react-dom": 1.2.1_biqbaboplfbrettd7655fr4n2y
       "@floating-ui/react-dom-interactions": 0.13.3_biqbaboplfbrettd7655fr4n2y
       "@headlessui/react": 1.7.6_biqbaboplfbrettd7655fr4n2y
       clsx: 1.2.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,8 +159,10 @@ importers:
   packages/core:
     specifiers:
       "@docsearch/react": ^3.3.0
+      "@floating-ui/react-dom-interactions": ^0.13.3
       "@headlessui/react": ^1.7.6
       clsx: ^1.2.1
+      framer-motion: ^8.4.3
       kbar: 0.1.0-beta.39
       mdx-mermaid: ^1.3.2
       mermaid: ^9.3.0
@@ -171,8 +173,10 @@ importers:
       react-dom: ^18.0.0
     dependencies:
       "@docsearch/react": 3.3.0_ftygaz6e6e5e4cecsqmsnm4myu
+      "@floating-ui/react-dom-interactions": 0.13.3_biqbaboplfbrettd7655fr4n2y
       "@headlessui/react": 1.7.6_biqbaboplfbrettd7655fr4n2y
       clsx: 1.2.1
+      framer-motion: 8.4.3_biqbaboplfbrettd7655fr4n2y
       kbar: 0.1.0-beta.39_biqbaboplfbrettd7655fr4n2y
       mdx-mermaid: 1.3.2_uudnhwjralaaj4jw3es27f6qki
       mermaid: 9.3.0
@@ -212,6 +216,7 @@ importers:
       "@flowershow/remark-wiki-link": ^1.0.0
       "@heroicons/react": ^1.0.4
       "@silvenon/remark-smartypants": ^1.0.0
+      "@tailwindcss/line-clamp": ^0.4.2
       "@tailwindcss/typography": ^0.5.2
       autoprefixer: ^10.4.4
       contentlayer: ^0.2.8
@@ -243,6 +248,7 @@ importers:
       "@flowershow/remark-wiki-link": link:../remark-wiki-link
       "@heroicons/react": 1.0.6_react@18.2.0
       "@silvenon/remark-smartypants": 1.0.0
+      "@tailwindcss/line-clamp": 0.4.2_tailwindcss@3.2.4
       "@tailwindcss/typography": 0.5.8_tailwindcss@3.2.4
       contentlayer: 0.2.9_esbuild@0.14.54
       date-fns: 2.29.3
@@ -2655,6 +2661,25 @@ packages:
       }
     dev: false
 
+  /@emotion/is-prop-valid/0.8.8:
+    resolution:
+      {
+        integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==,
+      }
+    requiresBuild: true
+    dependencies:
+      "@emotion/memoize": 0.7.4
+    dev: false
+    optional: true
+
+  /@emotion/memoize/0.7.4:
+    resolution:
+      {
+        integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==,
+      }
+    dev: false
+    optional: true
+
   /@esbuild-plugins/node-resolve/0.1.4_esbuild@0.14.54:
     resolution:
       {
@@ -2733,6 +2758,55 @@ packages:
       {
         integrity: sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==,
       }
+    dev: false
+
+  /@floating-ui/core/1.1.0:
+    resolution:
+      {
+        integrity: sha512-zbsLwtnHo84w1Kc8rScAo5GMk1GdecSlrflIbfnEBJwvTSj1SL6kkOYV+nHraMCPEy+RNZZUaZyL8JosDGCtGQ==,
+      }
+    dev: false
+
+  /@floating-ui/dom/1.1.0:
+    resolution:
+      {
+        integrity: sha512-TSogMPVxbRe77QCj1dt8NmRiJasPvuc+eT5jnJ6YpLqgOD2zXc5UA3S1qwybN+GVCDNdKfpKy1oj8RpzLJvh6A==,
+      }
+    dependencies:
+      "@floating-ui/core": 1.1.0
+    dev: false
+
+  /@floating-ui/react-dom-interactions/0.13.3_biqbaboplfbrettd7655fr4n2y:
+    resolution:
+      {
+        integrity: sha512-AnCW06eIZxzD/Hl1Qbi2JkQRU5KpY7Dn81k3xRfbvs+HylhB+t3x88/GNKLK39mMTlJ/ylxm5prUpiLrTWvifQ==,
+      }
+    deprecated: Package renamed to @floating-ui/react
+    peerDependencies:
+      react: ">=16.8.0"
+      react-dom: ">=16.8.0"
+    dependencies:
+      "@floating-ui/react-dom": 1.2.1_biqbaboplfbrettd7655fr4n2y
+      aria-hidden: 1.2.2_react@18.2.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      tabbable: 6.0.1
+    transitivePeerDependencies:
+      - "@types/react"
+    dev: false
+
+  /@floating-ui/react-dom/1.2.1_biqbaboplfbrettd7655fr4n2y:
+    resolution:
+      {
+        integrity: sha512-YCLlqibZtgUhxUpxkSp1oekvYgH/jI4KdZEJv85E62twlZHN43xdlQNe6JcF4ROD3/Zu6juNHN+aOygN+6yZjg==,
+      }
+    peerDependencies:
+      react: ">=16.8.0"
+      react-dom: ">=16.8.0"
+    dependencies:
+      "@floating-ui/dom": 1.1.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
     dev: false
 
   /@grpc/grpc-js/1.8.0:
@@ -3486,6 +3560,71 @@ packages:
       vfile: 5.3.6
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /@motionone/animation/10.15.1:
+    resolution:
+      {
+        integrity: sha512-mZcJxLjHor+bhcPuIFErMDNyrdb2vJur8lSfMCsuCB4UyV8ILZLvK+t+pg56erv8ud9xQGK/1OGPt10agPrCyQ==,
+      }
+    dependencies:
+      "@motionone/easing": 10.15.1
+      "@motionone/types": 10.15.1
+      "@motionone/utils": 10.15.1
+      tslib: 2.4.1
+    dev: false
+
+  /@motionone/dom/10.15.5:
+    resolution:
+      {
+        integrity: sha512-Xc5avlgyh3xukU9tydh9+8mB8+2zAq+WlLsC3eEIp7Ax7DnXgY7Bj/iv0a4X2R9z9ZFZiaXK3BO0xMYHKbAAdA==,
+      }
+    dependencies:
+      "@motionone/animation": 10.15.1
+      "@motionone/generators": 10.15.1
+      "@motionone/types": 10.15.1
+      "@motionone/utils": 10.15.1
+      hey-listen: 1.0.8
+      tslib: 2.4.1
+    dev: false
+
+  /@motionone/easing/10.15.1:
+    resolution:
+      {
+        integrity: sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==,
+      }
+    dependencies:
+      "@motionone/utils": 10.15.1
+      tslib: 2.4.1
+    dev: false
+
+  /@motionone/generators/10.15.1:
+    resolution:
+      {
+        integrity: sha512-67HLsvHJbw6cIbLA/o+gsm7h+6D4Sn7AUrB/GPxvujse1cGZ38F5H7DzoH7PhX+sjvtDnt2IhFYF2Zp1QTMKWQ==,
+      }
+    dependencies:
+      "@motionone/types": 10.15.1
+      "@motionone/utils": 10.15.1
+      tslib: 2.4.1
+    dev: false
+
+  /@motionone/types/10.15.1:
+    resolution:
+      {
+        integrity: sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA==,
+      }
+    dev: false
+
+  /@motionone/utils/10.15.1:
+    resolution:
+      {
+        integrity: sha512-p0YncgU+iklvYr/Dq4NobTRdAPv9PveRDUXabPEeOjBLSO/1FNB2phNTZxOxpi1/GZwYpAoECEa0Wam+nsmhSw==,
+      }
+    dependencies:
+      "@motionone/types": 10.15.1
+      hey-listen: 1.0.8
+      tslib: 2.4.1
     dev: false
 
   /@next/env/13.0.6:
@@ -5169,6 +5308,17 @@ packages:
     dependencies:
       tslib: 2.4.1
 
+  /@tailwindcss/line-clamp/0.4.2_tailwindcss@3.2.4:
+    resolution:
+      {
+        integrity: sha512-HFzAQuqYCjyy/SX9sLGB1lroPzmcnWv1FHkIpmypte10hptf4oPUfucryMKovZh2u0uiS9U5Ty3GghWfEJGwVw==,
+      }
+    peerDependencies:
+      tailwindcss: ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
+    dependencies:
+      tailwindcss: 3.2.4_postcss@8.4.20
+    dev: false
+
   /@tailwindcss/typography/0.5.8_tailwindcss@3.2.4:
     resolution:
       {
@@ -6684,6 +6834,23 @@ packages:
       {
         integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
       }
+
+  /aria-hidden/1.2.2_react@18.2.0:
+    resolution:
+      {
+        integrity: sha512-6y/ogyDTk/7YAe91T3E2PR1ALVKyM2QbTio5HwM+N1Q6CMlCKhvClyIjkckBswa0f2xJhjsfzIGa1yVSe1UMVA==,
+      }
+    engines: { node: ">=10" }
+    peerDependencies:
+      "@types/react": ^16.9.0 || ^17.0.0 || ^18.0.0
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+    dependencies:
+      react: 18.2.0
+      tslib: 2.4.1
+    dev: false
 
   /aria-query/4.2.2:
     resolution:
@@ -11380,6 +11547,24 @@ packages:
       }
     dev: true
 
+  /framer-motion/8.4.3_biqbaboplfbrettd7655fr4n2y:
+    resolution:
+      {
+        integrity: sha512-UMfJ8hEOlIObdJgI+U/VgaSSKY+W9/E0YtnFHPDsIE9rNPglaFZ+oycB0gj8ERuRBInGaIgNCFsil8iaJHZFgA==,
+      }
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    dependencies:
+      "@motionone/dom": 10.15.5
+      hey-listen: 1.0.8
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      tslib: 2.4.1
+    optionalDependencies:
+      "@emotion/is-prop-valid": 0.8.8
+    dev: false
+
   /fresh/0.5.2:
     resolution:
       {
@@ -12031,6 +12216,13 @@ packages:
       }
     hasBin: true
     dev: true
+
+  /hey-listen/1.0.8:
+    resolution:
+      {
+        integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==,
+      }
+    dev: false
 
   /hosted-git-info/2.8.9:
     resolution:
@@ -20111,6 +20303,13 @@ packages:
       "@pkgr/utils": 2.3.1
       tslib: 2.4.1
     dev: true
+
+  /tabbable/6.0.1:
+    resolution:
+      {
+        integrity: sha512-SYJSIgeyXW7EuX1ytdneO5e8jip42oHWg9xl/o3oTYhmXusZVgiA+VlPvjIN+kHii9v90AmzTZEBcsEvuAY+TA==,
+      }
+    dev: false
 
   /tailwindcss/3.2.4_postcss@8.4.20:
     resolution:

--- a/site/content/docs/link-previews.md
+++ b/site/content/docs/link-previews.md
@@ -13,12 +13,12 @@ After hovering over a link, the tooltip will be displayed as seen in the screens
 If your page has an image in the frontmatter, the image will also be displayed in the following style
 ![[link-preview-with-image.jpg]]
 
-This feature is enabled by default and if not required, it can be toggled off by setting the `linkPreviews` variable to false in your `config.js` file.
+This feature is enabled by default and if not required, it can be toggled off by adding the `showLinkPreviews` property and setting it to false in your `config.js` file.
 
 ```js
 // config.js
 
 const config = {
-  linkPreviews: false,
+  showLinkPreviews: false,
 };
 ```


### PR DESCRIPTION
Closes #36 
### Summary

This PR adds the feature to show previews for internal pages on hovering over it's link. This feature can also be disabled by setting `showLinkPreviews` property to false in `config.js` (enabled by default)

### Changes
* Add new packages:
  * core: 
    - `@floating-ui/react-dom`
    - `@floating-ui/react-dom-interactions`
    - `framer-motion`
  * template: `@tailwindcss/line-clamp`
* Add new Tooltip Component in core
* Modify CustomLink component in core
* Modify props for `CustomLink in template/pages/[[...slug]].jsx`
* Add tooltip styles in `template/styles/global.css`
* Add tailwind plugin in `template/tailwind.config.cjs`
* pnpm-lock updated
* update documentation in [docs/link-previews](https://deploy-preview-382--spectacular-dragon-c1015c.netlify.app/docs/link-previews)

### Screenshot preview

<img width="846" alt="Screen Shot 2023-01-18" src="https://user-images.githubusercontent.com/42637597/213283946-c7b0c959-ac8a-4aa2-935a-14053ca24d67.png">
