### PR TITLE
Using components (in MDX) that import from next package (e.g. next/link)

### DIFF
--- a/.changeset/silly-ways-exercise.md
+++ b/.changeset/silly-ways-exercise.md
@@ -1,0 +1,5 @@
+---
+"@flowershow/template": patch
+---
+
+Fix importing custom components, that import from `next` package (e.g. `next/link`)

--- a/packages/template-e2e/project.json
+++ b/packages/template-e2e/project.json
@@ -8,7 +8,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "src/support/testsetup.sh ../template src/fixtures/content",
+          "src/support/testsetup.sh ../template src/fixtures/content src/fixtures/components",
           "playwright test",
           "src/support/testteardown.sh"
         ],

--- a/packages/template-e2e/src/fixtures/components/NextLinkButton.jsx
+++ b/packages/template-e2e/src/fixtures/components/NextLinkButton.jsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+
+export function NextLinkButton({ children, href }) {
+  return (
+    <div
+      style={{
+        padding: 10,
+        backgroundColor: "#333",
+        color: "#fff",
+        display: "inline-block",
+        borderRadius: 4,
+      }}
+      onClick={() => alert("Hi")}
+    >
+      <Link
+        href={href}
+        className="text-blue-700 hover:text-blue-900"
+        legacyBehavior
+      >
+        {children}
+      </Link>
+    </div>
+  );
+}

--- a/packages/template-e2e/src/fixtures/content/mdxFeatures.md
+++ b/packages/template-e2e/src/fixtures/content/mdxFeatures.md
@@ -1,0 +1,11 @@
+# MDX features
+
+## Custom MDX components
+
+### Components that use Next.js Link
+
+import { NextLinkButton } from "components/custom/NextLinkButton.jsx";
+
+<div id="nextlinkbutton">
+<NextLinkButton href="/fixturepage">I'm a Next Link Button</NextLinkButton>
+</div>

--- a/packages/template-e2e/src/support/testsetup.sh
+++ b/packages/template-e2e/src/support/testsetup.sh
@@ -2,16 +2,21 @@
 
 TEMPLATE_DIR=$1
 CONTENT_DIR=$2
+COMPONENTS_DIR=$3
 E2E_TEMP_DIR=$(mktemp -d)
 
 cp -r $TEMPLATE_DIR $E2E_TEMP_DIR
+# TODO we don't need to copy content and components
 cp -r $CONTENT_DIR $E2E_TEMP_DIR
+cp -r $COMPONENTS_DIR $E2E_TEMP_DIR
 
 TEMP_TEMPLATE_DIR=$E2E_TEMP_DIR/$(basename $TEMPLATE_DIR)
 TEMP_CONTENT_DIR=$E2E_TEMP_DIR/$(basename $CONTENT_DIR)
+TEMP_COMPONENTS_DIR=$E2E_TEMP_DIR/$(basename $COMPONENTS_DIR)
 
 ln -vfns $TEMP_CONTENT_DIR $TEMP_TEMPLATE_DIR/content
 ln -vfns $TEMP_CONTENT_DIR/assets $TEMP_TEMPLATE_DIR/public/assets
+ln -vfns $TEMP_COMPONENTS_DIR $TEMP_TEMPLATE_DIR/components/custom
 
 # template package is using local versions of our remark plugins
 # this is enabled in the template's package.json with "workspace:*" used instead of a package version

--- a/packages/template-e2e/src/tests/mdxFeatures.spec.js
+++ b/packages/template-e2e/src/tests/mdxFeatures.spec.js
@@ -1,0 +1,17 @@
+const { test, expect } = require("@playwright/test");
+const { MarkdownPage } = require("../support/markdown-page");
+
+test.describe.parallel("custom components", () => {
+  test.beforeEach(async ({ page }) => {
+    const Page = new MarkdownPage(page);
+    await Page.goto("/mdxFeatures");
+    await Page.getData();
+  });
+
+  test("components using Next.js Link", async ({ page }) => {
+    const link = page.locator("#nextlinkbutton a");
+    await expect(link).toContainText("I'm a Next Link Button");
+    await link.click();
+    await expect(page).toHaveURL("/fixturepage");
+  });
+});

--- a/packages/template/pages/[[...slug]].jsx
+++ b/packages/template/pages/[[...slug]].jsx
@@ -10,8 +10,17 @@ import { getAuthorsDetails } from "../lib/getAuthorsDetails";
 import layouts from "../layouts";
 import { siteConfig } from "../config/siteConfig";
 
+// workaround solution to allow importing components
+// that import from "next" package (e.g. next/link) in MDX pages
+// more info: https://github.com/contentlayerdev/contentlayer/issues/288
+const codePrefix = `
+if (typeof process === 'undefined') {
+  globalThis.process = { env: {} }
+}
+`;
+
 export default function Page({ globals, body, ...meta }) {
-  const MDXPage = useMDXComponent(body.code, globals);
+  const MDXPage = useMDXComponent(codePrefix + body.code, globals);
   const { image, title, description } = meta;
 
   const MDXComponents = {


### PR DESCRIPTION
Closes #319

## Summary
This PR fixes a problem with importing components that import Next.js components like `Link`, in markdown pages.
The solution was proposed by the contentlayer team; see https://github.com/contentlayerdev/contentlayer/issues/288).

## Changes
- tweaks code string passed to contentlayer's `useMdxComponent` hook, by adding a prefix that set's the value of `process` variable
- adds relevant test files