### PR TITLE
fix-nav-background-and-text-color

### DIFF
--- a/packages/core/src/ui/BlogLayout/BlogLayout.tsx
+++ b/packages/core/src/ui/BlogLayout/BlogLayout.tsx
@@ -9,7 +9,7 @@ export const BlogLayout: React.FC<Props> = ({ children, ...frontMatter }) => {
   const { title, created, authorsDetails } = frontMatter;
 
   return (
-    <article className="docs prose prose-headings:font-headings dark:prose-invert prose-a:break-words mx-auto p-6">
+    <article className="docs prose prose-a:text-primary dark:prose-a:text-primary-dark prose-strong:text-primary dark:prose-strong:text-primary-dark prose-code:text-primary dark:prose-code:text-primary-dark prose-headings:text-primary dark:prose-headings:text-primary-dark prose text-primary dark:text-primary-dark prose-headings:font-headings dark:prose-invert prose-a:break-words mx-auto p-6">
       <header>
         <div className="mb-4 flex-col items-center">
           {title && <h1 className="flex justify-center">{title}</h1>}

--- a/packages/core/src/ui/DocsLayout/Docs.tsx
+++ b/packages/core/src/ui/DocsLayout/Docs.tsx
@@ -5,7 +5,7 @@ import { formatDate } from "../../utils/formatDate";
 export const DocsLayout: React.FC<any> = ({ children, ...frontMatter }) => {
   const { title, created } = frontMatter;
   return (
-    <article className="docs prose text-primary dark:text-primary-dark dark:prose-invert prose-headings:font-headings prose-a:break-words mx-auto p-6">
+    <article className="docs prose prose-a:text-primary dark:prose-a:text-primary-dark prose-strong:text-primary dark:prose-strong:text-primary-dark prose-code:text-primary dark:prose-code:text-primary-dark prose-headings:text-primary dark:prose-headings:text-primary-dark prose text-primary dark:text-primary-dark dark:prose-invert prose-headings:font-headings prose-a:break-words mx-auto p-6">
       <header>
         <div className="mb-6">
           {created && (

--- a/packages/core/src/ui/Nav/Nav.tsx
+++ b/packages/core/src/ui/Nav/Nav.tsx
@@ -54,7 +54,7 @@ export const Nav: React.FC<Props> = ({
         sticky top-0 z-50 flex items-center justify-between px-4 py-5 sm:px-6 lg:px-8 max-w-full
         ${
           isScrolled
-            ? "dark:bg-background-dark/95 bg-background/95 backdrop-blur"
+            ? "dark:bg-background-dark/95 bg-background/95 backdrop-blur [@supports(backdrop-filter:blur(0))]:dark:bg-background-dark/75"
             : "dark:bg-background-dark bg-background"
         }
       `}

--- a/packages/core/src/ui/Nav/Nav.tsx
+++ b/packages/core/src/ui/Nav/Nav.tsx
@@ -52,7 +52,11 @@ export const Nav: React.FC<Props> = ({
     <header
       className={`
         sticky top-0 z-50 flex items-center justify-between px-4 py-5 sm:px-6 lg:px-8 max-w-full
-        ${isScrolled ? "backdrop-blur" : ""}
+        ${
+          isScrolled
+            ? "dark:bg-background-dark/95 bg-background/95 backdrop-blur"
+            : "dark:bg-background-dark bg-background"
+        }
       `}
     >
       {/* Mobile navigation  */}

--- a/packages/core/src/ui/Nav/Nav.tsx
+++ b/packages/core/src/ui/Nav/Nav.tsx
@@ -52,11 +52,7 @@ export const Nav: React.FC<Props> = ({
     <header
       className={`
         sticky top-0 z-50 flex items-center justify-between px-4 py-5 sm:px-6 lg:px-8 max-w-full
-        ${
-          isScrolled
-            ? "dark:bg-slate-900/95 backdrop-blur [@supports(backdrop-filter:blur(0))]:dark:bg-slate-900/75"
-            : "dark:bg-slate-900"
-        }
+        ${isScrolled ? "backdrop-blur" : ""}
       `}
     >
       {/* Mobile navigation  */}


### PR DESCRIPTION
closes #400 

## Summary
Added some classes to layouts so headings and other tags uses tailwind config for colors

## Changes
- Added text-primary classes to headings, links, strong tags etc. in `Bloglayout` and `Docs`
- fix default background color in Nav
