### PR TITLE
Page comments / discussions

### DIFF
--- a/.changeset/silver-buses-tap.md
+++ b/.changeset/silver-buses-tap.md
@@ -1,0 +1,5 @@
+---
+"@flowershow/core": patch
+---
+
+Add: Page comments feature with support for three providers - giscus, utterances and disqus.

--- a/.changeset/silver-buses-tap.md
+++ b/.changeset/silver-buses-tap.md
@@ -1,5 +1,5 @@
 ---
-"@flowershow/core": patch
+"@flowershow/core": minor
 ---
 
 Add: Page comments feature with support for three providers - giscus, utterances and disqus.

--- a/.changeset/silver-buses-tap.md
+++ b/.changeset/silver-buses-tap.md
@@ -1,5 +1,0 @@
----
-"@flowershow/core": minor
----
-
-Add: Page comments feature with support for three providers - giscus, utterances and disqus.

--- a/.changeset/wicked-grapes-hug.md
+++ b/.changeset/wicked-grapes-hug.md
@@ -1,0 +1,5 @@
+---
+"@flowershow/template": minor
+---
+
+Add page comments feature

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @flowershow/core
 
+## 0.2.0
+
+### Minor Changes
+
+- 0ff6c06: Add: Page comments feature with support for three providers - giscus, utterances and disqus.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowershow/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Core Flowershow components, configs and utils.",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,10 +37,5 @@
     "next-themes": "^0.2.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
-  },
-  "overrides": {
-    "kbar": {
-      "react": "^17.0.0"
-    }
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,7 @@
     "@docsearch/react": "^3.3.0",
     "@floating-ui/react-dom": "^1.2.1",
     "@floating-ui/react-dom-interactions": "^0.13.3",
+    "@giscus/react": "^2.2.6",
     "@headlessui/react": "^1.7.6",
     "clsx": "^1.2.1",
     "framer-motion": "^8.4.3",
@@ -35,5 +36,10 @@
     "next-themes": "^0.2.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
+  },
+  "overrides": {
+    "kbar": {
+      "react": "^17.0.0"
+    }
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "@giscus/react": "^2.2.6",
     "@headlessui/react": "^1.7.6",
     "clsx": "^1.2.1",
+    "disqus-react": "^1.1.5",
     "framer-motion": "^8.4.3",
     "kbar": "0.1.0-beta.39",
     "mdx-mermaid": "^1.3.2",

--- a/packages/core/src/ui/Comments/Disqus.tsx
+++ b/packages/core/src/ui/Comments/Disqus.tsx
@@ -1,0 +1,52 @@
+// import { useEffect, useCallback } from 'react'
+import { DiscussionEmbed } from "disqus-react";
+
+export interface DisqusConfig {
+  provider: "disqus";
+  pages?: Array<string>;
+  config: {
+    shortname: string;
+  };
+}
+
+export type DisqusProps = DisqusConfig["config"] & {
+  slug?: string;
+};
+
+export const Disqus = ({ shortname, slug }: DisqusProps) => {
+  return (
+    <DiscussionEmbed
+      shortname={shortname}
+      config={{
+        url: window?.location?.href,
+        identifier: slug,
+      }}
+    />
+  );
+  // const COMMENTS_ID = 'disqus_thread'
+
+  // const LoadComments = useCallback(() => {
+  //   window.disqus_config = function () {
+  //     this.page.url = window.location.href
+  //     this.page.identifier = slug
+  //   }
+  //   if (window.DISQUS === undefined) {
+  //     const script = document.createElement('script')
+  //     script.src = 'https://' + shortname + '.disqus.com/embed.js'
+  //     // @ts-ignore
+  //     script.setAttribute('data-timestamp', +new Date())
+  //     script.setAttribute('crossorigin', 'anonymous')
+  //     script.async = true
+  //     document.body.appendChild(script)
+  //   } else {
+  //     //@ts-ignore
+  //     window.DISQUS.reset({ reload: true })
+  //   }
+  // }, [])
+
+  // useEffect(() => {
+  //   LoadComments()
+  // }, [LoadComments])
+
+  // return <div className="disqus-frame" id={COMMENTS_ID} />
+};

--- a/packages/core/src/ui/Comments/Disqus.tsx
+++ b/packages/core/src/ui/Comments/Disqus.tsx
@@ -1,4 +1,3 @@
-// import { useEffect, useCallback } from 'react'
 import { DiscussionEmbed } from "disqus-react";
 
 export interface DisqusConfig {
@@ -13,7 +12,7 @@ export type DisqusProps = DisqusConfig["config"] & {
   slug?: string;
 };
 
-export const Disqus = ({ shortname, slug }: DisqusProps) => {
+export const Disqus: React.FC<DisqusProps> = ({ shortname, slug }) => {
   return (
     <DiscussionEmbed
       shortname={shortname}
@@ -23,30 +22,4 @@ export const Disqus = ({ shortname, slug }: DisqusProps) => {
       }}
     />
   );
-  // const COMMENTS_ID = 'disqus_thread'
-
-  // const LoadComments = useCallback(() => {
-  //   window.disqus_config = function () {
-  //     this.page.url = window.location.href
-  //     this.page.identifier = slug
-  //   }
-  //   if (window.DISQUS === undefined) {
-  //     const script = document.createElement('script')
-  //     script.src = 'https://' + shortname + '.disqus.com/embed.js'
-  //     // @ts-ignore
-  //     script.setAttribute('data-timestamp', +new Date())
-  //     script.setAttribute('crossorigin', 'anonymous')
-  //     script.async = true
-  //     document.body.appendChild(script)
-  //   } else {
-  //     //@ts-ignore
-  //     window.DISQUS.reset({ reload: true })
-  //   }
-  // }, [])
-
-  // useEffect(() => {
-  //   LoadComments()
-  // }, [LoadComments])
-
-  // return <div className="disqus-frame" id={COMMENTS_ID} />
 };

--- a/packages/core/src/ui/Comments/Giscus.tsx
+++ b/packages/core/src/ui/Comments/Giscus.tsx
@@ -6,14 +6,13 @@ export interface GiscusConfig {
   pages?: Array<string>;
   config: {
     theme?: string;
-    darkTheme?: string;
-    mapping?: Mapping;
-    repo?: Repo;
-    repositoryId?: string;
-    category?: string;
-    categoryId?: string;
-    reactions?: string;
-    metadata?: string;
+    mapping: Mapping;
+    repo: Repo;
+    repositoryId: string;
+    category: string;
+    categoryId: string;
+    reactions: BooleanString;
+    metadata: BooleanString;
     inputPosition?: string;
     lang?: string;
   };
@@ -21,7 +20,7 @@ export interface GiscusConfig {
 
 export type GiscusProps = GiscusConfig["config"];
 
-export const GiscusReactComponent = ({
+export const GiscusReactComponent: React.FC<GiscusProps> = ({
   repo,
   repositoryId,
   category,
@@ -30,7 +29,7 @@ export const GiscusReactComponent = ({
   metadata = "0",
   mapping = "pathname",
   theme = "light",
-}: GiscusProps) => {
+}) => {
   const { theme: nextTheme, resolvedTheme } = useTheme();
   const commentsTheme =
     nextTheme === "dark" || resolvedTheme === "dark"
@@ -39,14 +38,14 @@ export const GiscusReactComponent = ({
 
   return (
     <Giscus
-      repo={repo as Repo}
-      repoId={repositoryId as string}
-      category={category as string}
-      categoryId={categoryId as string}
-      mapping={mapping as Mapping}
+      repo={repo}
+      repoId={repositoryId}
+      category={category}
+      categoryId={categoryId}
+      mapping={mapping}
       inputPosition="top"
-      reactionsEnabled={reactions as BooleanString}
-      emitMetadata={metadata as BooleanString}
+      reactionsEnabled={reactions}
+      emitMetadata={metadata}
       // TODO: remove transparent_dark after theme toggle fix
       theme={nextTheme ? commentsTheme : "transparent_dark"}
     />

--- a/packages/core/src/ui/Comments/Giscus.tsx
+++ b/packages/core/src/ui/Comments/Giscus.tsx
@@ -1,0 +1,54 @@
+import Giscus, { BooleanString, Mapping, Repo } from "@giscus/react";
+import { useTheme } from "next-themes";
+
+export interface GiscusConfig {
+  provider: "giscus";
+  pages?: Array<string>;
+  config: {
+    theme?: string;
+    darkTheme?: string;
+    mapping?: Mapping;
+    repo?: Repo;
+    repositoryId?: string;
+    category?: string;
+    categoryId?: string;
+    reactions?: string;
+    metadata?: string;
+    inputPosition?: string;
+    lang?: string;
+  };
+}
+
+export type GiscusProps = GiscusConfig["config"];
+
+export const GiscusReactComponent = ({
+  repo,
+  repositoryId,
+  category,
+  categoryId,
+  reactions = "0",
+  metadata = "0",
+  mapping = "pathname",
+  theme = "light",
+}: GiscusProps) => {
+  const { theme: nextTheme, resolvedTheme } = useTheme();
+  const commentsTheme =
+    nextTheme === "dark" || resolvedTheme === "dark"
+      ? "transparent_dark"
+      : theme;
+
+  return (
+    <Giscus
+      repo={repo as Repo}
+      repoId={repositoryId as string}
+      category={category as string}
+      categoryId={categoryId as string}
+      mapping={mapping as Mapping}
+      inputPosition="top"
+      reactionsEnabled={reactions as BooleanString}
+      emitMetadata={metadata as BooleanString}
+      // TODO: remove transparent_dark after theme toggle fix
+      theme={nextTheme ? commentsTheme : "transparent_dark"}
+    />
+  );
+};

--- a/packages/core/src/ui/Comments/Utterances.tsx
+++ b/packages/core/src/ui/Comments/Utterances.tsx
@@ -6,20 +6,20 @@ export interface UtterancesConfig {
   pages?: Array<string>;
   config: {
     theme?: string;
-    repo?: string;
-    label?: string;
-    issueTerm?: string;
+    repo: string;
+    label: string;
+    issueTerm: string;
   };
 }
 
 export type UtterancesProps = UtterancesConfig["config"];
 
-export const Utterances = ({
+export const Utterances: React.FC<UtterancesProps> = ({
   repo,
   label = "comments",
   issueTerm = "pathname",
   theme = "github-light",
-}: UtterancesProps) => {
+}) => {
   const { theme: nextTheme, resolvedTheme } = useTheme();
   // TODO: remove preferred-color-scheme after theme toggle fix
   const commentsTheme = nextTheme
@@ -33,10 +33,10 @@ export const Utterances = ({
   const LoadComments = useCallback(() => {
     const script = document.createElement("script");
     script.src = "https://utteranc.es/client.js";
-    script.setAttribute("repo", repo as string);
-    script.setAttribute("issue-term", issueTerm as string);
-    script.setAttribute("label", label as string);
-    script.setAttribute("theme", commentsTheme as string);
+    script.setAttribute("repo", repo);
+    script.setAttribute("issue-term", issueTerm);
+    script.setAttribute("label", label);
+    script.setAttribute("theme", commentsTheme);
     script.setAttribute("crossorigin", "anonymous");
     script.async = true;
 

--- a/packages/core/src/ui/Comments/Utterances.tsx
+++ b/packages/core/src/ui/Comments/Utterances.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useCallback } from "react";
+import { useTheme } from "next-themes";
+
+export interface UtterancesConfig {
+  provider: "utterances";
+  pages?: Array<string>;
+  config: {
+    theme?: string;
+    repo?: string;
+    label?: string;
+    issueTerm?: string;
+  };
+}
+
+export type UtterancesProps = UtterancesConfig["config"];
+
+export const Utterances = ({
+  repo,
+  label = "comments",
+  issueTerm = "pathname",
+  theme = "github-light",
+}: UtterancesProps) => {
+  const { theme: nextTheme, resolvedTheme } = useTheme();
+  // TODO: remove preferred-color-scheme after theme toggle fix
+  const commentsTheme = nextTheme
+    ? nextTheme === "dark" || resolvedTheme === "dark"
+      ? "github-dark"
+      : theme
+    : "preferred-color-scheme";
+
+  const COMMENTS_ID = "comments-container";
+
+  const LoadComments = useCallback(() => {
+    const script = document.createElement("script");
+    script.src = "https://utteranc.es/client.js";
+    script.setAttribute("repo", repo as string);
+    script.setAttribute("issue-term", issueTerm as string);
+    script.setAttribute("label", label as string);
+    script.setAttribute("theme", commentsTheme as string);
+    script.setAttribute("crossorigin", "anonymous");
+    script.async = true;
+
+    const comments = document.getElementById(COMMENTS_ID);
+    if (comments) comments.appendChild(script);
+
+    return () => {
+      const comments = document.getElementById(COMMENTS_ID);
+      if (comments) comments.innerHTML = "";
+    };
+  }, [commentsTheme, issueTerm]);
+
+  // Reload on theme change
+  useEffect(() => {
+    LoadComments();
+  }, [LoadComments]);
+
+  // Added `relative` to fix a weird bug with `utterances-frame` position
+  return <div className="utterances-frame relative" id={COMMENTS_ID} />;
+};

--- a/packages/core/src/ui/Comments/index.tsx
+++ b/packages/core/src/ui/Comments/index.tsx
@@ -1,17 +1,17 @@
 import dynamic from "next/dynamic.js";
 import { GiscusReactComponent, GiscusConfig, GiscusProps } from "./Giscus";
 import { Utterances, UtterancesConfig, UtterancesProps } from "./Utterances";
+import { Disqus, DisqusConfig, DisqusProps } from "./Disqus";
 
-// TODO: add disqus support
-// declare global {
-//   interface Window {
-//     disqus_config?: (...args: any[]) => void;
-//     DISQUS?: (...args: any[]) => void;
-//     page?: any;
-//   }
-// }
+declare global {
+  interface Window {
+    disqus_config?: (...args: any[]) => void;
+    DISQUS?: (...args: any[]) => void;
+    page?: any;
+  }
+}
 
-export type CommentsConfig = GiscusConfig | UtterancesConfig;
+export type CommentsConfig = GiscusConfig | UtterancesConfig | DisqusConfig;
 
 export interface CommentsProps {
   commentsConfig: CommentsConfig;
@@ -32,6 +32,13 @@ const UtterancesComponent = dynamic<UtterancesProps>(
   { ssr: false }
 );
 
+const DisqusComponent = dynamic<DisqusProps>(
+  () => {
+    return import("./Disqus").then((mod) => mod.Disqus);
+  },
+  { ssr: false }
+);
+
 /**
  * Supports Giscus, Utterances
  * If you want to use a comments provider you have to add it to the
@@ -47,8 +54,17 @@ export const Comments = ({ commentsConfig, slug }: CommentsProps) => {
       return <GiscusComponent {...commentsConfig.config} />;
     case "utterances":
       return <UtterancesComponent {...commentsConfig.config} />;
+    case "disqus":
+      return <DisqusComponent slug={slug} {...commentsConfig.config} />;
   }
 };
 
-export { GiscusReactComponent, Utterances };
-export type { GiscusConfig, GiscusProps, UtterancesConfig, UtterancesProps };
+export { GiscusReactComponent, Utterances, Disqus };
+export type {
+  GiscusConfig,
+  GiscusProps,
+  UtterancesConfig,
+  UtterancesProps,
+  DisqusConfig,
+  DisqusProps,
+};

--- a/packages/core/src/ui/Comments/index.tsx
+++ b/packages/core/src/ui/Comments/index.tsx
@@ -1,0 +1,54 @@
+import dynamic from "next/dynamic.js";
+import { GiscusReactComponent, GiscusConfig, GiscusProps } from "./Giscus";
+import { Utterances, UtterancesConfig, UtterancesProps } from "./Utterances";
+
+// TODO: add disqus support
+// declare global {
+//   interface Window {
+//     disqus_config?: (...args: any[]) => void;
+//     DISQUS?: (...args: any[]) => void;
+//     page?: any;
+//   }
+// }
+
+export type CommentsConfig = GiscusConfig | UtterancesConfig;
+
+export interface CommentsProps {
+  commentsConfig: CommentsConfig;
+  slug?: string;
+}
+
+const GiscusComponent = dynamic<GiscusProps>(
+  () => {
+    return import("./Giscus").then((mod) => mod.GiscusReactComponent);
+  },
+  { ssr: false }
+);
+
+const UtterancesComponent = dynamic<UtterancesProps>(
+  () => {
+    return import("./Utterances").then((mod) => mod.Utterances);
+  },
+  { ssr: false }
+);
+
+/**
+ * Supports Giscus, Utterances
+ * If you want to use a comments provider you have to add it to the
+ * content security policy in the `next.config.js` file.
+ * slug is used in disqus to identify the page
+ *
+ * @param {CommentsProps} { comments, slug }
+ * @return {*}
+ */
+export const Comments = ({ commentsConfig, slug }: CommentsProps) => {
+  switch (commentsConfig.provider) {
+    case "giscus":
+      return <GiscusComponent {...commentsConfig.config} />;
+    case "utterances":
+      return <UtterancesComponent {...commentsConfig.config} />;
+  }
+};
+
+export { GiscusReactComponent, Utterances };
+export type { GiscusConfig, GiscusProps, UtterancesConfig, UtterancesProps };

--- a/packages/core/src/ui/Comments/index.tsx
+++ b/packages/core/src/ui/Comments/index.tsx
@@ -3,14 +3,6 @@ import { GiscusReactComponent, GiscusConfig, GiscusProps } from "./Giscus";
 import { Utterances, UtterancesConfig, UtterancesProps } from "./Utterances";
 import { Disqus, DisqusConfig, DisqusProps } from "./Disqus";
 
-declare global {
-  interface Window {
-    disqus_config?: (...args: any[]) => void;
-    DISQUS?: (...args: any[]) => void;
-    page?: any;
-  }
-}
-
 export type CommentsConfig = GiscusConfig | UtterancesConfig | DisqusConfig;
 
 export interface CommentsProps {
@@ -39,15 +31,6 @@ const DisqusComponent = dynamic<DisqusProps>(
   { ssr: false }
 );
 
-/**
- * Supports Giscus, Utterances
- * If you want to use a comments provider you have to add it to the
- * content security policy in the `next.config.js` file.
- * slug is used in disqus to identify the page
- *
- * @param {CommentsProps} { comments, slug }
- * @return {*}
- */
 export const Comments = ({ commentsConfig, slug }: CommentsProps) => {
   switch (commentsConfig.provider) {
     case "giscus":

--- a/packages/core/src/ui/Layout/Layout.tsx
+++ b/packages/core/src/ui/Layout/Layout.tsx
@@ -24,7 +24,6 @@ interface Props extends React.PropsWithChildren {
   showComments: boolean;
   commentsConfig: CommentsConfig;
   edit_url?: string;
-  raw?: any; // TODO type
 }
 
 export const Layout: React.FC<Props> = ({

--- a/packages/core/src/ui/Layout/Layout.tsx
+++ b/packages/core/src/ui/Layout/Layout.tsx
@@ -47,8 +47,13 @@ export const Layout: React.FC<Props> = ({
   const currentSection = useTableOfContents(tableOfContents);
   const router: NextRouter = useRouter();
 
+  /**
+   * showing page comments either set through frontmatter,
+   * or set in config's pages property. frontmatter takes precedence.
+   * if neither are set then defaults to show on all pages.
+   */
   const showPageComments =
-    showComments ?? commentsConfig?.pages?.includes(raw.sourceFileDir);
+    showComments ?? commentsConfig?.pages?.includes(raw?.sourceFileDir) ?? true;
 
   useEffect(() => {
     if (!showToc) return;

--- a/packages/core/src/ui/Layout/Layout.tsx
+++ b/packages/core/src/ui/Layout/Layout.tsx
@@ -11,6 +11,7 @@ import { TableOfContents } from "./TableOfContents";
 import { Sidebar, PageLink } from "./Sidebar";
 import { NavConfig, AuthorConfig, ThemeConfig, TocSection } from "../types";
 import { NextRouter, useRouter } from "next/router.js";
+import { Comments, CommentsConfig } from "../Comments";
 
 interface Props extends React.PropsWithChildren {
   nav: NavConfig;
@@ -20,7 +21,10 @@ interface Props extends React.PropsWithChildren {
   showEditLink: boolean;
   showSidebar: boolean;
   url_path: string;
+  showComments: boolean;
+  commentsConfig?: CommentsConfig;
   edit_url?: string;
+  raw?: any; // TODO type
 }
 
 export const Layout: React.FC<Props> = ({
@@ -32,13 +36,19 @@ export const Layout: React.FC<Props> = ({
   showToc,
   showSidebar,
   url_path,
+  showComments,
+  commentsConfig,
   edit_url,
+  raw,
 }) => {
   const [isScrolled, setIsScrolled] = useState(false);
   const [tableOfContents, setTableOfContents] = useState<TocSection[]>([]);
   const [sitemap, setSitemap] = useState<PageLink[]>([]);
   const currentSection = useTableOfContents(tableOfContents);
   const router: NextRouter = useRouter();
+
+  const showPageComments =
+    showComments ?? commentsConfig?.pages?.includes(raw.sourceFileDir);
 
   useEffect(() => {
     if (!showToc) return;
@@ -124,6 +134,20 @@ export const Layout: React.FC<Props> = ({
             {children}
             {/* EDIT THIS PAGE LINK */}
             {showEditLink && edit_url && <EditThisPage url={edit_url} />}
+            {/* PAGE COMMENTS */}
+            {commentsConfig && showPageComments && (
+              <div
+                className="prose mx-auto pt-6 pb-6 text-center text-gray-700 dark:text-gray-300"
+                id="comment"
+              >
+                {
+                  <Comments
+                    commentsConfig={commentsConfig}
+                    slug={raw?.flattenedPath}
+                  />
+                }
+              </div>
+            )}
           </main>
           <Footer links={nav.links} author={author} />
           {/** TABLE OF CONTENTS */}

--- a/packages/core/src/ui/Layout/Layout.tsx
+++ b/packages/core/src/ui/Layout/Layout.tsx
@@ -22,7 +22,7 @@ interface Props extends React.PropsWithChildren {
   showSidebar: boolean;
   url_path: string;
   showComments: boolean;
-  commentsConfig?: CommentsConfig;
+  commentsConfig: CommentsConfig;
   edit_url?: string;
   raw?: any; // TODO type
 }
@@ -39,21 +39,12 @@ export const Layout: React.FC<Props> = ({
   showComments,
   commentsConfig,
   edit_url,
-  raw,
 }) => {
   const [isScrolled, setIsScrolled] = useState(false);
   const [tableOfContents, setTableOfContents] = useState<TocSection[]>([]);
   const [sitemap, setSitemap] = useState<PageLink[]>([]);
   const currentSection = useTableOfContents(tableOfContents);
   const router: NextRouter = useRouter();
-
-  /**
-   * showing page comments either set through frontmatter,
-   * or set in config's pages property. frontmatter takes precedence.
-   * if neither are set then defaults to show on all pages.
-   */
-  const showPageComments =
-    showComments ?? commentsConfig?.pages?.includes(raw?.sourceFileDir) ?? true;
 
   useEffect(() => {
     if (!showToc) return;
@@ -140,17 +131,12 @@ export const Layout: React.FC<Props> = ({
             {/* EDIT THIS PAGE LINK */}
             {showEditLink && edit_url && <EditThisPage url={edit_url} />}
             {/* PAGE COMMENTS */}
-            {commentsConfig && showPageComments && (
+            {showComments && (
               <div
                 className="prose mx-auto pt-6 pb-6 text-center text-gray-700 dark:text-gray-300"
                 id="comment"
               >
-                {
-                  <Comments
-                    commentsConfig={commentsConfig}
-                    slug={raw?.flattenedPath}
-                  />
-                }
+                {<Comments commentsConfig={commentsConfig} slug={url_path} />}
               </div>
             )}
           </main>

--- a/packages/core/src/ui/types.ts
+++ b/packages/core/src/ui/types.ts
@@ -71,6 +71,7 @@ interface SharedFields {
   layout: string;
   showEditLink?: boolean;
   showToc?: boolean;
+  showComments?: boolean;
   isDraft?: boolean;
   data: Array<string>;
 }

--- a/packages/template/contentlayer.config.ts
+++ b/packages/template/contentlayer.config.ts
@@ -25,6 +25,7 @@ const sharedFields: any = {
   showEditLink: { type: "boolean" },
   showToc: { type: "boolean" },
   showSidebar: { type: "boolean" },
+  showComments: { type: "boolean" },
   isDraft: { type: "boolean" },
   data: { type: "list", of: { type: "string" }, default: [] },
 };

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -12,7 +12,7 @@
     "generate": "contentlayer build && cross-env NODE_OPTIONS=\"--experimental-json-modules --experimental-modules\" node ./scripts/search.mjs"
   },
   "dependencies": {
-    "@flowershow/core": "^0.1.0",
+    "@flowershow/core": "^0.2.0",
     "@flowershow/remark-callouts": "^1.0.0",
     "@flowershow/remark-embed": "^1.0.0",
     "@flowershow/remark-wiki-link": "^1.0.0",

--- a/packages/template/pages/_app.tsx
+++ b/packages/template/pages/_app.tsx
@@ -16,15 +16,25 @@ import "../styles/prism.css";
 function MyApp({ Component, pageProps }) {
   const router = useRouter();
 
+  /**
+   * Page comments
+   * Showing page comments either set through frontmatter,
+   * or set in config's pages property. Frontmatter takes precedence.
+   * if neither are set then defaults to show on all pages.
+   */
+  const showComments =
+    pageProps.showComments ??
+    siteConfig?.comments?.pages?.includes(pageProps._raw?.sourceFileDir) ??
+    true;
+
   // TODO maybe use computed fields for showEditLink and showToc to make this even cleaner?
   const layoutProps = {
     showToc: pageProps.showToc ?? siteConfig.showToc,
     showEditLink: pageProps.showEditLink ?? siteConfig.showEditLink,
-    showComments: pageProps.showComments,
-    commentsConfig: siteConfig.comments,
     edit_url: pageProps.edit_url,
     url_path: pageProps.url_path,
-    raw: pageProps._raw,
+    commentsConfig: siteConfig.comments,
+    showComments,
     nav: {
       title: siteConfig.navbarTitle?.text || siteConfig.title,
       logo: siteConfig.navbarTitle?.logo,

--- a/packages/template/pages/_app.tsx
+++ b/packages/template/pages/_app.tsx
@@ -20,8 +20,11 @@ function MyApp({ Component, pageProps }) {
   const layoutProps = {
     showToc: pageProps.showToc ?? siteConfig.showToc,
     showEditLink: pageProps.showEditLink ?? siteConfig.showEditLink,
+    showComments: pageProps.showComments,
+    commentsConfig: siteConfig.comments,
     edit_url: pageProps.edit_url,
     url_path: pageProps.url_path,
+    raw: pageProps._raw,
     nav: {
       title: siteConfig.navbarTitle?.text || siteConfig.title,
       logo: siteConfig.navbarTitle?.logo,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,7 @@ importers:
       "@giscus/react": ^2.2.6
       "@headlessui/react": ^1.7.6
       clsx: ^1.2.1
+      disqus-react: ^1.1.5
       framer-motion: ^8.4.3
       kbar: 0.1.0-beta.39
       mdx-mermaid: ^1.3.2
@@ -180,6 +181,7 @@ importers:
       "@giscus/react": 2.2.6_biqbaboplfbrettd7655fr4n2y
       "@headlessui/react": 1.7.6_biqbaboplfbrettd7655fr4n2y
       clsx: 1.2.1
+      disqus-react: 1.1.5_biqbaboplfbrettd7655fr4n2y
       framer-motion: 8.4.3_biqbaboplfbrettd7655fr4n2y
       kbar: 0.1.0-beta.39_biqbaboplfbrettd7655fr4n2y
       mdx-mermaid: 1.3.2_uudnhwjralaaj4jw3es27f6qki
@@ -9518,6 +9520,19 @@ packages:
     dependencies:
       path-type: 4.0.0
     dev: true
+
+  /disqus-react/1.1.5_biqbaboplfbrettd7655fr4n2y:
+    resolution:
+      {
+        integrity: sha512-9fdG5m6c3wJzlCDLaMheuUagMVj3s5qgUSXdekpCsvzYOKG21AiuOoqyDzA0oXrpPnYzgpnsvPYqZ+i0hJPGZw==,
+      }
+    peerDependencies:
+      react: ^15.6.1 || ^16.0.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^15.6.1 || ^16.0.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
 
   /dlv/1.1.3:
     resolution:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,7 @@ importers:
       "@docsearch/react": ^3.3.0
       "@floating-ui/react-dom": ^1.2.1
       "@floating-ui/react-dom-interactions": ^0.13.3
+      "@giscus/react": ^2.2.6
       "@headlessui/react": ^1.7.6
       clsx: ^1.2.1
       framer-motion: ^8.4.3
@@ -176,6 +177,7 @@ importers:
       "@docsearch/react": 3.3.0_ftygaz6e6e5e4cecsqmsnm4myu
       "@floating-ui/react-dom": 1.2.1_biqbaboplfbrettd7655fr4n2y
       "@floating-ui/react-dom-interactions": 0.13.3_biqbaboplfbrettd7655fr4n2y
+      "@giscus/react": 2.2.6_biqbaboplfbrettd7655fr4n2y
       "@headlessui/react": 1.7.6_biqbaboplfbrettd7655fr4n2y
       clsx: 1.2.1
       framer-motion: 8.4.3_biqbaboplfbrettd7655fr4n2y
@@ -2821,6 +2823,20 @@ packages:
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
+  /@giscus/react/2.2.6_biqbaboplfbrettd7655fr4n2y:
+    resolution:
+      {
+        integrity: sha512-qGjikDm7euLOCfMPn500d7F3UIl/qI55/dWF4ALC5Fo/7i5qktKCAwy6/zop93PjP0hJL6mi54K6x36SyvaLyQ==,
+      }
+    peerDependencies:
+      react: ^16 || ^17 || ^18
+      react-dom: ^16 || ^17 || ^18
+    dependencies:
+      giscus: 1.2.6
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
+
   /@grpc/grpc-js/1.8.0:
     resolution:
       {
@@ -3504,6 +3520,22 @@ packages:
         integrity: sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==,
       }
     dev: true
+
+  /@lit-labs/ssr-dom-shim/1.0.0:
+    resolution:
+      {
+        integrity: sha512-ic93MBXfApIFTrup4a70M/+ddD8xdt2zxxj9sRwHQzhS9ag/syqkD8JPdTXsc1gUy2K8TTirhlCqyTEM/sifNw==,
+      }
+    dev: false
+
+  /@lit/reactive-element/1.6.1:
+    resolution:
+      {
+        integrity: sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==,
+      }
+    dependencies:
+      "@lit-labs/ssr-dom-shim": 1.0.0
+    dev: false
 
   /@manypkg/find-root/1.1.0:
     resolution:
@@ -6030,6 +6062,13 @@ packages:
         integrity: sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==,
       }
     dev: true
+
+  /@types/trusted-types/2.0.2:
+    resolution:
+      {
+        integrity: sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==,
+      }
+    dev: false
 
   /@types/unist/2.0.6:
     resolution:
@@ -11757,6 +11796,15 @@ packages:
       }
     dev: true
 
+  /giscus/1.2.6:
+    resolution:
+      {
+        integrity: sha512-VqMWmCdlUk9krX2M3oMgn9/Y6XEbRXRHtfhNTuRn/AdeGOeko54OFEIsizQ/nYWymuUNGZR48KGptCtYL77rtA==,
+      }
+    dependencies:
+      lit: 2.6.1
+    dev: false
+
   /github-slugger/1.5.0:
     resolution:
       {
@@ -14724,6 +14772,36 @@ packages:
       through: 2.3.8
       wrap-ansi: 7.0.0
     dev: true
+
+  /lit-element/3.2.2:
+    resolution:
+      {
+        integrity: sha512-6ZgxBR9KNroqKb6+htkyBwD90XGRiqKDHVrW/Eh0EZ+l+iC+u+v+w3/BA5NGi4nizAVHGYvQBHUDuSmLjPp7NQ==,
+      }
+    dependencies:
+      "@lit/reactive-element": 1.6.1
+      lit-html: 2.6.1
+    dev: false
+
+  /lit-html/2.6.1:
+    resolution:
+      {
+        integrity: sha512-Z3iw+E+3KKFn9t2YKNjsXNEu/LRLI98mtH/C6lnFg7kvaqPIzPn124Yd4eT/43lyqrejpc5Wb6BHq3fdv4S8Rw==,
+      }
+    dependencies:
+      "@types/trusted-types": 2.0.2
+    dev: false
+
+  /lit/2.6.1:
+    resolution:
+      {
+        integrity: sha512-DT87LD64f8acR7uVp7kZfhLRrHkfC/N4BVzAtnw9Yg8087mbBJ//qedwdwX0kzDbxgPccWRW6mFwGbRQIxy0pw==,
+      }
+    dependencies:
+      "@lit/reactive-element": 1.6.1
+      lit-element: 3.2.2
+      lit-html: 2.6.1
+    dev: false
 
   /load-yaml-file/0.2.0:
     resolution:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,7 +216,7 @@ importers:
 
   packages/template:
     specifiers:
-      "@flowershow/core": ^0.1.0
+      "@flowershow/core": ^0.2.0
       "@flowershow/remark-callouts": ^1.0.0
       "@flowershow/remark-embed": ^1.0.0
       "@flowershow/remark-wiki-link": ^1.0.0

--- a/site/content/assets/images/page_comments.png
+++ b/site/content/assets/images/page_comments.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c00c70498071616ce287d5860f11d875aa88010d63dd65161d7b1454cb1a1a6
+size 118089

--- a/site/content/blog/index.md
+++ b/site/content/blog/index.md
@@ -5,6 +5,7 @@ showSidebar: false
 showToc: false
 data:
   - blogs
+showComments: false
 ---
 
 <BlogsList blogs={blogs}/>

--- a/site/content/config.js
+++ b/site/content/config.js
@@ -14,6 +14,16 @@ const config = {
   showEditLink: true,
   showToc: true,
   showSidebar: false,
+  comments: {
+    provider: "giscus", // supported providers: giscus, utterances
+    pages: ["blog"], // page directories where we want commments
+    config: {
+      repo: process.env.NEXT_PUBLIC_GISCUS_REPO,
+      repositoryId: process.env.NEXT_PUBLIC_GISCUS_REPOSITORY_ID,
+      category: process.env.NEXT_PUBLIC_GISCUS_CATEGORY,
+      categoryId: process.env.NEXT_PUBLIC_GISCUS_CATEGORY_ID,
+    },
+  },
   analytics: "G-RQWLTRWBS2",
   navLinks: [
     { href: "/#overview", name: "Overview" },

--- a/site/content/config.js
+++ b/site/content/config.js
@@ -15,7 +15,7 @@ const config = {
   showToc: true,
   showSidebar: false,
   comments: {
-    provider: "giscus", // supported providers: giscus, utterances
+    provider: "giscus", // supported providers: giscus, utterances, disqus
     pages: ["blog"], // page directories where we want commments
     config: {
       repo: process.env.NEXT_PUBLIC_GISCUS_REPO,

--- a/site/content/docs/index.md
+++ b/site/content/docs/index.md
@@ -32,3 +32,4 @@ Flowershow supports **CommonMark** and **GitHub Flavored Markdown**, but also ma
 13. [[theme|Dark-light theme]]
 14. [[search|Full-text search]]
 15. [[docs/blog|Blog support]]
+16. [[page-comments|Page comments]]

--- a/site/content/docs/page-comments.md
+++ b/site/content/docs/page-comments.md
@@ -6,18 +6,18 @@ Flowershow supports the integration of a user commenting feature on your website
 
 ![[page_comments.png]]
 
+## Setup
+
 Page comments can be setup with any one of the following supported providers:
 
 1. [giscus](https://giscus.app/)
 2. [utterances](https://utteranc.es/)
 3. [disqus](https://disqus.com/)
 
-## Using environment variables
-
-Each provider has it's own config values and it is highly recommended that you store them as environment variables rather than putting them in your config file directly. You can do so by creating a `.env` file in the `.flowershow` folder and adding the values as seen below.
+Each provider has it's own configuration options. It is highly recommended that you store them as environment variables rather than putting them in your config file directly. You can do so by creating a `.env` file in the `.flowershow` folder and adding the values as seen below.
 
 > [!note]
-> If you are hosting your website on hosting providers like netlify, vercel or clouflare, you will need to add the below env variables using their admin user interface and can skip the step of adding a `.env` file. Please follow their documentation on how to add environment variables.
+> If you are hosting your website on hosting providers like Netlify, Vercel or Cloudflare, you will also need to add the environment variables there. Please follow their documentation to learn how to do this.
 
 ### Giscus
 
@@ -59,15 +59,17 @@ const config = {
 
 ## Setting up comments using giscus
 
-[Giscus](https://giscus.app/) uses your github repo's discussions feature to store your comments and display them on your site. To setup comments with giscus there are a few prerequisites to follow.
+[Giscus](https://giscus.app/) uses your github repo's discussions feature to store your comments and display them on your site.
 
-1. Have a public [github repo](https://docs.github.com/en/get-started/quickstart/create-a-repo) where you would like to store your comments and activate the [discussions](https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/enabling-or-disabling-github-discussions-for-a-repository) feature.
-2. Install the [giscus app](https://github.com/apps/giscus) in your repo by following their configuration setup at https://giscus.app/
+### Prerequisites
+
+1. You have a public [github repository](https://docs.github.com/en/get-started/quickstart/create-a-repo) with the [discussions](https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/enabling-or-disabling-github-discussions-for-a-repository) feature acitvated which would be used to store your comments.
+2. The [giscus app](https://github.com/apps/giscus) installed in your repo by following their configuration setup at https://giscus.app/
 
 Once the above steps are completed, we will have to get our config values. Head over to https://giscus.app and follow the steps there by filling out the fields.
 
 > [!important]
-> make sure to choose `pathname` under page discussions mapping.
+> Make sure to choose `pathname` under page discussions mapping.
 
 After filling out the fields, you will be provided with a script tag that contains your config values. Now you are ready to enable giscus comments by adding these values in your config file.
 
@@ -77,10 +79,10 @@ const config = {
   comments: {
     provider: "giscus",
     config: {
-      repo: "your repo",
-      repositoryId: "your repo id",
-      category: "your repo category name",
-      categoryId: "your repo category id",
+      repo: process.env.NEXT_PUBLIC_GISCUS_REPO,
+      repositoryId: process.env.NEXT_PUBLIC_GISCUS_REPOSITORY_ID,
+      category: process.env.NEXT_PUBLIC_GISCUS_CATEGORY,
+      categoryId: process.env.NEXT_PUBLIC_GISCUS_CATEGORY_ID,
     },
   },
 };
@@ -90,7 +92,10 @@ const config = {
 
 [Utterances](https://utteranc.es/) uses your github repo's issues to store comments for your pages and display them on your site. To setup comments with utterances, you would need to do the following:
 
-1. Have a public github repository and install the utterances app by following their configuration setup at https://utteranc.es/
+### Prerequisites
+
+1. You have a public [github repository](https://docs.github.com/en/get-started/quickstart/create-a-repo)
+2. The utterances app installed in your repo by following their configuration setup at https://utteranc.es/
 
 Once installed fill in the required fields and you will see a script tag with your repo value which you can add in your config file as seen below.
 
@@ -99,7 +104,7 @@ const config = {
   comments: {
     provider: "utterances",
     config: {
-      repo: "your repo here",
+      repo: process.env.NEXT_PUBLIC_UTTERANCES_REPO,
     },
   },
 };
@@ -109,18 +114,27 @@ const config = {
 
 [Disqus](https://disqus.com/) is a feature rich provider which can be used to add comments to your site. You can configure flowershow to use disqus by creating an account on their site and following their process. You will be asked to enter a shortname for your site. Once completed, we can use this shortname in our comments configuration as below.
 
+### Prerequisites
+
+1. Create an account on [Disqus](https://disqus.com/) and follow their setup process.
+
+> [!note]
+> You will be asked to enter a shortname for your site. You'll need it for disqus comments configuration as seen below.
+
 ```js
 const config = {
   comments: {
     provider: "disqus",
     config: {
-      shortname: "your disqus shortname",
+      shortname: process.env.NEXT_PUBLIC_DISQUS_SHORTNAME,
     },
   },
 };
 ```
 
 ## Showing comments on pages
+
+By default, comments show up on all the pages after they have been added in your config file.
 
 ### Enable / disable comments for individual pages
 
@@ -134,7 +148,7 @@ showComments: true
 
 ### Enable / disable comments for pages in a directory
 
-We can also setup comments for all pages within a specific directory by passing a pages property whose values are an array of strings.
+We can also enable comments for all pages within a specific directory by passing a pages property whose values are an array of strings.
 
 ```js
 const config = {

--- a/site/content/docs/page-comments.md
+++ b/site/content/docs/page-comments.md
@@ -1,0 +1,148 @@
+---
+title: Page comments
+---
+
+Flowershow supports the integration of a user commenting feature on your website, allowing visitors to provide their feedback and thoughts on your pages. This functionality can be configured in the config file and can be optionally added to each page's frontmatter for more granular control.
+
+![[page_comments.png]]
+
+Page comments can be setup with any one of the following supported providers:
+
+1. [giscus](https://giscus.app/)
+2. [utterances](https://utteranc.es/)
+3. [disqus](https://disqus.com/)
+
+## Using environment variables
+
+Each provider has it's own config values and it is highly recommended that you store them as environment variables rather than putting them in your config file directly. You can do so by creating a `.env` file in the `.flowershow` folder and adding the values as seen below.
+
+> [!note]
+> If you are hosting your website on hosting providers like netlify, vercel or clouflare, you will need to add the below env variables using their admin user interface and can skip the step of adding a `.env` file. Please follow their documentation on how to add environment variables.
+
+### Giscus
+
+```
+NEXT_PUBLIC_GISCUS_REPO=
+NEXT_PUBLIC_GISCUS_REPOSITORY_ID=
+NEXT_PUBLIC_GISCUS_CATEGORY=
+NEXT_PUBLIC_GISCUS_CATEGORY_ID=
+```
+
+### Utterances
+
+```
+NEXT_PUBLIC_UTTERANCES_REPO=
+```
+
+### Disqus
+
+```
+NEXT_PUBLIC_DISQUS_SHORTNAME=
+```
+
+Then you can use environment variables in your config file with `process.env`. For example, you can see how we can use these in the code below.
+
+```js
+// config.js
+
+const config = {
+  comments: {
+    provider: 'giscus',
+    config: {
+      repo: process.env.NEXT_PUBLIC_GISCUS_REPO,
+      repositoryId: process.env.NEXT_PUBLIC_GISCUS_REPOSITORY_ID
+      ...
+    }
+  }
+}
+```
+
+## Setting up comments using giscus
+
+[Giscus](https://giscus.app/) uses your github repo's discussions feature to store your comments and display them on your site. To setup comments with giscus there are a few prerequisites to follow.
+
+1. Have a public [github repo](https://docs.github.com/en/get-started/quickstart/create-a-repo) where you would like to store your comments and activate the [discussions](https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/enabling-or-disabling-github-discussions-for-a-repository) feature.
+2. Install the [giscus app](https://github.com/apps/giscus) in your repo by following their configuration setup at https://giscus.app/
+
+Once the above steps are completed, we will have to get our config values. Head over to https://giscus.app and follow the steps there by filling out the fields.
+
+> [!important]
+> make sure to choose `pathname` under page discussions mapping.
+
+After filling out the fields, you will be provided with a script tag that contains your config values. Now you are ready to enable giscus comments by adding these values in your config file.
+
+```js
+// config.js
+const config = {
+  comments: {
+    provider: "giscus",
+    config: {
+      repo: "your repo",
+      repositoryId: "your repo id",
+      category: "your repo category name",
+      categoryId: "your repo category id",
+    },
+  },
+};
+```
+
+## Setting up comments using utterances
+
+[Utterances](https://utteranc.es/) uses your github repo's issues to store comments for your pages and display them on your site. To setup comments with utterances, you would need to do the following:
+
+1. Have a public github repository and install the utterances app by following their configuration setup at https://utteranc.es/
+
+Once installed fill in the required fields and you will see a script tag with your repo value which you can add in your config file as seen below.
+
+```js
+const config = {
+  comments: {
+    provider: "utterances",
+    config: {
+      repo: "your repo here",
+    },
+  },
+};
+```
+
+## Setting up comments using disqus
+
+[Disqus](https://disqus.com/) is a feature rich provider which can be used to add comments to your site. You can configure flowershow to use disqus by creating an account on their site and following their process. You will be asked to enter a shortname for your site. Once completed, we can use this shortname in our comments configuration as below.
+
+```js
+const config = {
+  comments: {
+    provider: "disqus",
+    config: {
+      shortname: "your disqus shortname",
+    },
+  },
+};
+```
+
+## Showing comments on pages
+
+### Enable / disable comments for individual pages
+
+You can enable / disable comments on individual pages by adding a `showComments` field in the page's frontmatter and setting it's value to `true` or `false`.
+
+```md
+---
+showComments: true
+---
+```
+
+### Enable / disable comments for pages in a directory
+
+We can also setup comments for all pages within a specific directory by passing a pages property whose values are an array of strings.
+
+```js
+const config = {
+  comments: {
+    ...
+    pages: ["blog"],
+  }
+}
+```
+
+In the above configuration the pages property allows you to define on which pages you would like the comments feature to be shown. For example, if you have a _blog_ folder in your content and would like the comments to be enabled only on your blog pages then you can add it here.


### PR DESCRIPTION
Closes #163 
### Summary

This PR adds the feature to enable comments on pages by setting them up in config and/or frontmatter.

### Changes
* Create comments components in core for [giscus](https://giscus.app/), [utterances](https://utteranc.es/) and [disqus](https://disqus.com)
  * Add [giscus react](https://github.com/giscus/giscus-component) and [disqus-react](https://github.com/disqus/disqus-react) packages in core 
* Add configs in frontmatter and config.js
  * configured to set page comments through frontmatter, or specified folders in comments' config. If both are not set then defaults to show on all pages. Frontmatter value takes precedence.
* Add documentation @ [docs/page-comments](https://deploy-preview-406--spectacular-dragon-c1015c.netlify.app/docs/page-comments)

### TODO
- [x] add disqus support
- [x] Create documentation
- [x] publish core
- [x] Add giscuss env variables in netlify
- [x] install giscus app in flowershow repo

### Screenshot (giscus comments)
<img width="1429" alt="Screen Shot 2023-01-30 at 1 35 11 PM" src="https://user-images.githubusercontent.com/42637597/215459613-e3122d76-6d2f-4031-8684-fa81e33286de.png">

