### PR TITLE
Fix inline Latex display

### DIFF
--- a/packages/template/styles/global.css
+++ b/packages/template/styles/global.css
@@ -1,8 +1,8 @@
 @import "@flowershow/remark-callouts/styles.css";
 
 /* mathjax */
-.math-inline {
-  display: flex;
+.math-inline > mjx-container > svg {
+  display: inline;
   align-items: center;
 }
 


### PR DESCRIPTION
closes #272 

## Summary
- changed `math-inline` class in `template/styles/global.css`

Equations in sentences now displays:

![image](https://user-images.githubusercontent.com/44789132/219769702-5e68bee8-3e73-4e56-bf10-cb317b58f405.png)
