### PR TITLE
Auto extract title and description from content

### DIFF
--- a/.changeset/tender-ravens-fetch.md
+++ b/.changeset/tender-ravens-fetch.md
@@ -1,0 +1,5 @@
+---
+"@flowershow/template": minor
+---
+
+Auto extract title and description from content.

--- a/packages/template/contentlayer.config.ts
+++ b/packages/template/contentlayer.config.ts
@@ -50,12 +50,20 @@ const computedFields: ComputedFields = {
   title: {
     type: "string",
     /* eslint no-underscore-dangle: off */
-    resolve: (doc) => {
+    resolve: async (doc) => {
       // use frontmatter title if exists
       if (doc.title) return doc.title;
       // use h1 heading on first line (if exists)
       const heading = doc.body.raw.trim().match(/^#\s+(.*?)\n/);
-      if (heading) return heading[1];
+      if (heading) {
+        const title = heading[1]
+          // replace wikilink with only text value
+          .replace(/\[\[([\S]*?)]]/, "$1");
+
+        const stripTitle = await remark().use(stripMarkdown).process(title);
+
+        return stripTitle.toString().trim();
+      }
     },
   },
   description: {

--- a/packages/template/contentlayer.config.ts
+++ b/packages/template/contentlayer.config.ts
@@ -54,14 +54,13 @@ const computedFields: ComputedFields = {
       // use frontmatter title if exists
       if (doc.title) return doc.title;
       // use h1 heading on first line (if exists)
-      const heading = doc.body.raw.trim().match(/^#\s+(.*?)\n/);
+      const heading = doc.body.raw.trim().match(/^#\s+(.*)/);
       if (heading) {
         const title = heading[1]
           // replace wikilink with only text value
           .replace(/\[\[([\S]*?)]]/, "$1");
 
         const stripTitle = await remark().use(stripMarkdown).process(title);
-
         return stripTitle.toString().trim();
       }
     },

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -41,6 +41,7 @@
     "remark-math": "^5.1.1",
     "remark-smartypants": "^2.0.0",
     "remark-toc": "^8.0.1",
+    "strip-markdown": "^5.0.0",
     "typed.js": "^2.0.12",
     "typescript": "^4.9.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,7 @@ importers:
       remark-math: ^5.1.1
       remark-smartypants: ^2.0.0
       remark-toc: ^8.0.1
+      strip-markdown: ^5.0.0
       tailwindcss: ^3.2.7
       typed.js: ^2.0.12
       typescript: ^4.9.5
@@ -284,6 +285,7 @@ importers:
       remark-math: 5.1.1
       remark-smartypants: 2.0.0
       remark-toc: 8.0.1
+      strip-markdown: 5.0.0
       typed.js: 2.0.12
       typescript: 4.9.5
     devDependencies:
@@ -15412,6 +15414,14 @@ packages:
     dependencies:
       acorn: 8.8.2
     dev: true
+
+  /strip-markdown/5.0.0:
+    resolution: {integrity: sha512-PXSts6Ta9A/TwGxVVSRlQs1ukJTAwwtbip2OheJEjPyfykaQ4sJSTnQWjLTI2vYWNts/R/91/csagp15W8n9gA==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      '@types/unist': 2.0.6
+      unified: 10.1.2
+    dev: false
 
   /strong-log-transformer/2.1.0:
     resolution: {integrity: sha512-B3Hgul+z0L9a236FAUC9iZsL+nVHgoCJnqCbN588DjYxvGXaXaaFbfmQ/JhvKjZwsOukuR72XbHv71Qkug0HxA==}


### PR DESCRIPTION
Closes #297 
### Summary

Merging this PR will add meta title and description from content's (first) `H1`  and `paragraph` respectively, only if they are not specified in the page's frontmatter and if page content exists.

### Changes

* Add resolvers for title and description in computed fields - `contentlayer.config.ts`
* Add package - https://github.com/remarkjs/strip-markdown
* Handle repeating titles in `pages/[[...slug]].tsx`