### PR TITLE
Make date the default field in frontmatter

### DIFF
--- a/.changeset/khaki-toys-crash.md
+++ b/.changeset/khaki-toys-crash.md
@@ -1,0 +1,6 @@
+---
+"@flowershow/template": patch
+"@flowershow/core": patch
+---
+
+Make date frontmatter the default field being used, created can still be used in frontmatter

--- a/packages/core/src/ui/Blog/BlogItem.tsx
+++ b/packages/core/src/ui/Blog/BlogItem.tsx
@@ -13,11 +13,11 @@ export const BlogItem: React.FC<Props> = ({ blog }) => {
         <Card.Title href={`${blog.url_path}`}>{blog.title}</Card.Title>
         <Card.Eyebrow
           as="time"
-          dateTime={blog.created}
+          dateTime={blog.date}
           className="md:hidden"
           decorate
         >
-          {formatDate(blog.created)}
+          {formatDate(blog.date)}
         </Card.Eyebrow>
         {blog.description && (
           <Card.Description>{blog.description}</Card.Description>
@@ -26,10 +26,10 @@ export const BlogItem: React.FC<Props> = ({ blog }) => {
       </Card>
       <Card.Eyebrow
         as="time"
-        dateTime={blog.created}
+        dateTime={blog.date}
         className="mt-1 hidden md:block"
       >
-        {formatDate(blog.created)}
+        {formatDate(blog.date)}
       </Card.Eyebrow>
     </article>
   );

--- a/packages/core/src/ui/BlogLayout/BlogLayout.tsx
+++ b/packages/core/src/ui/BlogLayout/BlogLayout.tsx
@@ -6,16 +6,16 @@ import { Avatar } from "../Avatar";
 type Props = any;
 
 export const BlogLayout: React.FC<Props> = ({ children, ...frontMatter }) => {
-  const { title, created, authorsDetails } = frontMatter;
+  const { title, date, authorsDetails } = frontMatter;
 
   return (
     <article className="docs prose prose-a:text-primary dark:prose-a:text-primary-dark prose-strong:text-primary dark:prose-strong:text-primary-dark prose-code:text-primary dark:prose-code:text-primary-dark prose-headings:text-primary dark:prose-headings:text-primary-dark prose text-primary dark:text-primary-dark prose-headings:font-headings dark:prose-invert prose-a:break-words mx-auto p-6">
       <header>
         <div className="mb-4 flex-col items-center">
           {title && <h1 className="flex justify-center">{title}</h1>}
-          {created && (
+          {date && (
             <p className="text-sm text-zinc-400 dark:text-zinc-500 flex justify-center">
-              <time dateTime={created}>{formatDate(created)}</time>
+              <time dateTime={date}>{formatDate(date)}</time>
             </p>
           )}
           {authorsDetails && (

--- a/packages/core/src/ui/types.ts
+++ b/packages/core/src/ui/types.ts
@@ -45,12 +45,13 @@ interface SharedFields {
 interface ComputedFields {
   url_path: string;
   edit_url?: string;
+  date?: string;
 }
 
 export interface Page extends SharedFields, ComputedFields {}
 
 export interface Blog extends SharedFields, ComputedFields {
-  created: string; // TODO type?
+  date: string; // TODO type?
   authors?: Array<string>;
   tags?: Array<string>;
 }

--- a/packages/template-e2e/src/fixtures/content/getters/blogs.js
+++ b/packages/template-e2e/src/fixtures/content/getters/blogs.js
@@ -1,5 +1,5 @@
 import { allBlogs } from "contentlayer/generated";
 
 export default function getBlogs() {
-  return allBlogs.sort((a, b) => new Date(b.created) - new Date(a.created));
+  return allBlogs.sort((a, b) => new Date(b.date) - new Date(a.date));
 }

--- a/packages/template/contentlayer.config.ts
+++ b/packages/template/contentlayer.config.ts
@@ -48,6 +48,14 @@ const computedFields: ComputedFields = {
     /* eslint no-underscore-dangle: off */
     resolve: (doc) => doc._raw.flattenedPath.replace(/^(.+?\/)*/, ""),
   },
+  date: {
+    type: "date",
+    /* eslint no-underscore-dangle: off */
+    resolve: (doc) => {
+      if (doc.date) return doc.date;
+      else if (doc.created) return doc.created;
+    },
+  },
   title: {
     type: "string",
     /* eslint no-underscore-dangle: off */
@@ -128,7 +136,8 @@ const Blog = defineDocumentType(() => ({
   fields: {
     ...sharedFields,
     layout: { type: "string", default: "blog" },
-    created: { type: "date", required: true },
+    date: { type: "date", required: true },
+    created: { type: "date" },
     authors: {
       type: "list",
       of: { type: "string" },

--- a/packages/template/contentlayer.config.ts
+++ b/packages/template/contentlayer.config.ts
@@ -136,7 +136,7 @@ const Blog = defineDocumentType(() => ({
   fields: {
     ...sharedFields,
     layout: { type: "string", default: "blog" },
-    date: { type: "date", required: true },
+    date: { type: "date" },
     created: { type: "date" },
     authors: {
       type: "list",

--- a/packages/template/contentlayer.config.ts
+++ b/packages/template/contentlayer.config.ts
@@ -51,10 +51,7 @@ const computedFields: ComputedFields = {
   date: {
     type: "date",
     /* eslint no-underscore-dangle: off */
-    resolve: (doc) => {
-      if (doc.date) return doc.date;
-      else if (doc.created) return doc.created;
-    },
+    resolve: (doc) => doc.date ?? doc.created ?? null,
   },
   title: {
     type: "string",

--- a/site/content/blog/2022-11-21-updated-features.md
+++ b/site/content/blog/2022-11-21-updated-features.md
@@ -1,7 +1,7 @@
 ---
 title: Flowershow News November 2022
 description: Check out what's new in the latest version of Flowershow template and our CLI! 🚀🔥
-created: 2022-11-21
+date: 2022-11-21
 authors: [philippe-du-preez]
 ---
 

--- a/site/content/blog/2022-11-30-wordpress-migration.md
+++ b/site/content/blog/2022-11-30-wordpress-migration.md
@@ -1,7 +1,7 @@
 ---
 title: Wordpress to Flowershow migration tutorial
 description: Easily migrate your Wordpress content in 3 easy steps!
-created: 2022-11-30
+date: 2022-11-30
 authors: [philippe-du-preez]
 ---
 

--- a/site/content/blog/2022-12-08-updated-features.md
+++ b/site/content/blog/2022-12-08-updated-features.md
@@ -1,7 +1,7 @@
 ---
 title: Flowershow News December 2022
 description: Here are some of the new features we have implemented. 😎🚀
-created: 2022-12-08
+date: 2022-12-08
 authors: [philippe-du-preez]
 ---
 

--- a/site/content/blog/2023-01-25-updated-features.md
+++ b/site/content/blog/2023-01-25-updated-features.md
@@ -1,7 +1,7 @@
 ---
 title: Flowershow News January 2023
 description: Here are some of the new features we have implemented. 😎🚀
-created: 2023-01-25
+date: 2023-01-25
 authors: [philippe-du-preez]
 ---
 

--- a/site/content/blog/2023-02-16-nextjs-tutorial.md
+++ b/site/content/blog/2023-02-16-nextjs-tutorial.md
@@ -1,7 +1,7 @@
 ---
 title: Jumpstart a content-driven NextJS site with Flowershow
 description: This article will guide you through the process of building a basic static blog with Next.js using the Flowershow template.
-created: 2023-02-16
+date: 2023-02-16
 authors: [philippe-du-preez]
 ---
 

--- a/site/content/blog/2023-02-16-nextjs-tutorial.md
+++ b/site/content/blog/2023-02-16-nextjs-tutorial.md
@@ -153,7 +153,7 @@ my-flowershow-app
 
 If you looked at the schema of the `Blog` type in `contentlayer.config.ts` file, you noticed that apart from shared fields like title or description, this type has the following extra fields:
 
-- `created` (required) - date that will be displayed on the blog page and that will be used to sort your list of blogs (if you'll use our `BlogsList` component)
+- `date` - date that will be displayed on the blog page and that will be used to sort your list of blogs (if you'll use our `BlogsList` component)
 - `authors` (optional) - this will search for authors and display their images on the post ([Authors docs](https://flowershow.app/docs/blog#blog-authors))
 
 We will also need to add a title and a description of each blog, which will be displayed on the blog home page that we'll create later on.
@@ -164,7 +164,7 @@ So your `my-blog-post.md` file will look like this:
 ---
 title: Blog post title
 description: This blog post is about how to write a blog
-created: 2022-11-29
+date: 2022-11-29
 authors: [John Doe, Jane Doe]
 ---
 
@@ -210,7 +210,7 @@ In addition to that, you also need to create a getter function that will fetch a
 import { allBlogs } from "contentlayer/generated";
 
 export default function getBlogs() {
-  return allBlogs.sort((a, b) => new Date(b.created) - new Date(a.created));
+  return allBlogs.sort((a, b) => new Date(b.date) - new Date(a.date));
 }
 ```
 

--- a/site/content/blog/2023-02-17-updated-features.md
+++ b/site/content/blog/2023-02-17-updated-features.md
@@ -1,7 +1,7 @@
 ---
 title: Flowershow News February 2023
 description: Page comments, site wide table of contents and twitter embeds have been added. 😎🚀
-created: 2023-02-17
+date: 2023-02-17
 authors: [philippe-du-preez]
 ---
 

--- a/site/content/blog/alpha-release.md
+++ b/site/content/blog/alpha-release.md
@@ -1,7 +1,7 @@
 ---
 title: Alpha Release
 description: We've just released the first alpha of Flowershow for self-publishing 🙌 Publish your markdown digital garden (obsidian-powered or otherwise) as fast as lighting ⚡
-created: 2022-11-07
+date: 2022-11-07
 authors: [philippe-du-preez]
 ---
 

--- a/site/content/blog/flowershow-setup-v0.0.1-for-alpha-users-june-2022.md
+++ b/site/content/blog/flowershow-setup-v0.0.1-for-alpha-users-june-2022.md
@@ -1,7 +1,7 @@
 ---
 title: Flowershow Setup Guide v0.0.1 for Alpha Users (June 2022)
 authors: [rufuspollock, olayway]
-created: 2022-06-26
+date: 2022-06-26
 last-updated: 2022-07-18
 ---
 

--- a/site/content/docs/blog-section-tutorial.md
+++ b/site/content/docs/blog-section-tutorial.md
@@ -2,7 +2,7 @@
 title: Create a blog/news/articles site with Flowershow!
 description: Create a blog/news/articles site with Flowershow!
 type: Blog
-created: 2023-01-25
+date: 2023-01-25
 authors: [philippe-du-preez]
 ---
 

--- a/site/content/docs/blog-section-tutorial.md
+++ b/site/content/docs/blog-section-tutorial.md
@@ -33,13 +33,13 @@ Blog content here
 
 ## Blog post frontmatter fields
 
-- `created` (required) - date that will be displayed on the blog page and that will be used to sort blog search results
+- `date` - date that will be displayed on the blog page and that will be used to sort blog search results
 - `authors` (optional) - authors of the blog that will be displayed on the blog page
 
 ```md
 ---
 title: Blog post title
-created: 2022-11-29
+date: 2022-11-29
 authors: [John Doe, Jan Kowalski]
 ---
 
@@ -84,7 +84,7 @@ In addition to that, you also need to create a getter function that will fetch a
 // <your-content-folder>/getters/blogs.js
 import { allBlogs } from "contentlayer/generated";
 export default function getBlogs() {
-  return allBlogs.sort((a, b) => new Date(b.created) - new Date(a.created));
+  return allBlogs.sort((a, b) => new Date(b.date) - new Date(a.date));
 }
 ```
 
@@ -126,7 +126,7 @@ Now you can reference John in one of your blog pages using e.g. the name you've 
 ```md
 ---
 title: Some blog page
-created: 2022-12-12
+date: 2022-12-12
 authors: [John Doe]
 ---
 ```

--- a/site/content/docs/blog-tutorial.md
+++ b/site/content/docs/blog-tutorial.md
@@ -26,7 +26,7 @@ Now, in order for Flowershow to pick this file up as one of your blog files, we 
 title: My blog post
 description: My first Flowershow blog post!
 type: Blog
-created: 2022-11-29
+date: 2022-11-29
 authors: [John Doe]
 ---
 
@@ -74,7 +74,7 @@ Before we use the `BlogsList` component on this page, we also need to have a lis
 import { allBlogs } from "contentlayer/generated";
 
 export default function getBlogs() {
-  return allBlogs.sort((a, b) => new Date(b.created) - new Date(a.created));
+  return allBlogs.sort((a, b) => new Date(b.date) - new Date(a.date));
 }
 ```
 

--- a/site/content/docs/blog-tutorial.md
+++ b/site/content/docs/blog-tutorial.md
@@ -2,7 +2,7 @@
 title: Blog support
 description: Learn how to create an index page for your blog
 type: Blog
-created: 2022-11-29
+date: 2022-11-29
 authors: [Ola Rubaj]
 ---
 

--- a/site/content/docs/blog.md
+++ b/site/content/docs/blog.md
@@ -29,13 +29,13 @@ type: Blog
 
 ## Blog post frontmatter fields
 
-- `created` (required) - date that will be displayed on the blog page and that will be used to sort blog search results
+- `date` - date that will be displayed on the blog page and that will be used to sort blog search results
 - `authors` (optional)
 
 ```md
 ---
 title: Blog post title
-created: 2022-11-29
+date: 2022-11-29
 authors: [John Doe, Jan Kowalski]
 ---
 ```
@@ -61,7 +61,7 @@ In addition to that, you also need to create a getter function that will fetch a
 import { allBlogs } from "contentlayer/generated";
 
 export default function getBlogs() {
-  return allBlogs.sort((a, b) => new Date(b.created) - new Date(a.created));
+  return allBlogs.sort((a, b) => new Date(b.date) - new Date(a.date));
 }
 ```
 
@@ -108,7 +108,7 @@ Now you can reference John in one of your blog pages using e.g. the id you've se
 ```md
 ---
 title: Some blog page
-created: 2022-12-12
+date: 2022-12-12
 authors: [john123]
 ---
 ```
@@ -118,7 +118,7 @@ authors: [john123]
 ```md
 ---
 title: Some blog page
-created: 2022-12-12
+date: 2022-12-12
 authors: [john-doe]
 ---
 ```
@@ -128,7 +128,7 @@ authors: [john-doe]
 ```md
 ---
 title: Some blog page
-created: 2022-12-12
+date: 2022-12-12
 authors: [John Doe]
 ---
 ```

--- a/site/content/docs/comments.md
+++ b/site/content/docs/comments.md
@@ -2,7 +2,7 @@
 title: Empower Your Flowershow Website or Blog with User Comments
 description: "Get more feedback or simply increase visitor engagement by easily adding page comments to your Flowershow website or blog."
 type: Blog
-created: 2023-02-04
+date: 2023-02-04
 authors: [Khalil Ali]
 ---
 

--- a/site/content/docs/custom-theme.md
+++ b/site/content/docs/custom-theme.md
@@ -2,7 +2,7 @@
 title: How to theme your Flowershow website
 description: Learn how to add custom fonts and colors to your site
 type: Blog
-created: 2023-01-23
+date: 2023-01-23
 ---
 
 We are going to learn how to change the fonts and colors used throughout

--- a/site/content/docs/publish-tutorial.md
+++ b/site/content/docs/publish-tutorial.md
@@ -2,7 +2,7 @@
 title: Self publish your digital garden with Flowershow
 description: Learn how to create and publish your first Flowershow website 🌷
 type: Blog
-created: 2022-09-14
+date: 2022-09-14
 authors: [Ola Rubaj]
 ---
 

--- a/site/content/getters/blogs.js
+++ b/site/content/getters/blogs.js
@@ -2,11 +2,11 @@ import { allBlogs } from "contentlayer/generated";
 
 export default function getBlogs() {
   return allBlogs
-    .map(({ title, description = null, created, url_path }) => ({
+    .map(({ title, description = null, date, url_path }) => ({
       title,
       description,
-      created,
+      date,
       url_path,
     }))
-    .sort((a, b) => new Date(b.created) - new Date(a.created));
+    .sort((a, b) => new Date(b.date) - new Date(a.date));
 }

--- a/site/content/notes/content-layer.md
+++ b/site/content/notes/content-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Content Layer
-created: 2022-03-06
+date: 2022-03-06
 ---
 
 A Content Layer is an API to content, in our case markdown. It provides an intermediate layer between presentation layer and the raw content on disk.

--- a/site/content/notes/design-cloud-publishing.md
+++ b/site/content/notes/design-cloud-publishing.md
@@ -1,5 +1,5 @@
 ---
-created: 2022-11-22
+date: 2022-11-22
 title: Cloud Publishing Design
 ---
 

--- a/site/content/notes/digital-garden.md
+++ b/site/content/notes/digital-garden.md
@@ -1,7 +1,7 @@
 ---
 title: Digital Gardens
 description: "Digital Gardens. What they are and why create one"
-created: 2022-05-29
+date: 2022-05-29
 tags: [todo/tidy]
 ---
 

--- a/site/content/notes/howto-signups-for-petitions-in-jamstack-world.md
+++ b/site/content/notes/howto-signups-for-petitions-in-jamstack-world.md
@@ -1,6 +1,6 @@
 ---
 title: Research on how to do signups for petitions in JAMStack world
-created: 2020-04-05
+date: 2020-04-05
 ---
 
 I want to ...

--- a/site/content/notes/tutorial-flowershow-nextjs-template.md
+++ b/site/content/notes/tutorial-flowershow-nextjs-template.md
@@ -1,5 +1,5 @@
 ---
-created: 2022-09-23
+date: 2022-09-23
 ---
 
 # Flowershow as a NextJS template


### PR DESCRIPTION
closes #445 

## Summary
- Uses `date` as default frontmatter field and uses `created` field if `date` is not found

## Changes
- Blog layout components updated to use `date` instead of `created`
- `date` computed field added in `contentlayer.config`

## Notes
- Since either `created` or `date` can be used, none of them is required, maybe there is a way to have at least one of them required?
- Tested that both date and created frontmatter fields works as expected