### PR TITLE
Link previews per page added

### DIFF
--- a/.changeset/new-doors-fetch.md
+++ b/.changeset/new-doors-fetch.md
@@ -1,0 +1,5 @@
+---
+"@flowershow/template": patch
+---
+
+Link previews can be enabled/disabled per page

--- a/packages/template/contentlayer.config.ts
+++ b/packages/template/contentlayer.config.ts
@@ -33,6 +33,7 @@ const sharedFields: FieldDefs = {
   showSidebar: { type: "boolean" },
   showComments: { type: "boolean" },
   isDraft: { type: "boolean" },
+  showLinkPreview: { type: "boolean" },
   data: { type: "list", of: { type: "string" }, default: [] },
 };
 

--- a/packages/template/pages/[[...slug]].tsx
+++ b/packages/template/pages/[[...slug]].tsx
@@ -30,7 +30,7 @@ return {default: () => React.createElement('div', null, '')}
 export default function Page({ globals, body, ...meta }) {
   const pageCode = body.code.length > 0 ? body.code : defaultCode;
   const MDXPage = useMDXComponent(`${codePrefix}${pageCode}`, globals);
-  const { image, title, description } = meta;
+  const { image, title, description, showLinkPreview } = meta;
 
   // workaround to handle repeating titles
   // remove the first heading from markdown if it's a title and displayed on page
@@ -57,7 +57,7 @@ export default function Page({ globals, body, ...meta }) {
       <CustomLink
         data={allDocuments}
         usehook={useMDXComponent}
-        preview={siteConfig.showLinkPreviews}
+        preview={showLinkPreview ?? siteConfig.showLinkPreviews}
         {...props}
       />
     ),

--- a/site/content/docs/index.md
+++ b/site/content/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: Get Started with Flowershow
+showLinkPreview: false
 ---
 
 ## What is Flowershow?

--- a/site/content/docs/link-previews.md
+++ b/site/content/docs/link-previews.md
@@ -22,3 +22,13 @@ const config = {
   showLinkPreviews: false,
 };
 ```
+
+### Disable/Enable link preview for page
+
+You can also add/remove link previews for specific pages by setting  `showLinkPreview` to **true** or **false** in the page's frontmatter like below.
+
+```md
+---
+showLinkPreview: true
+---
+```

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -2,6 +2,7 @@
 layout: unstyled
 showToc: false
 showSidebar: false
+showLinkPreview: false
 ---
 
 import { Hero } from "components/custom/Hero.jsx"


### PR DESCRIPTION
closes #455 

Link previews boolean added to frontmatter

## Changes
- frontmatter value `showLinkPreview` will be used first if it exists instead of siteConfig value `showLinkPreviews`
- added change to docs at  `/docs/link-previews`
- changed our home page and docs index page to not display link previews