### PR TITLE
fix: respect explicit target attribute on external HTML links

### DIFF
--- a/apps/flowershow/lib/__tests__/rehype-html-enhancements.test.ts
+++ b/apps/flowershow/lib/__tests__/rehype-html-enhancements.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
+import rehypeStringify from 'rehype-stringify';
+import rehypeRaw from 'rehype-raw';
+import rehypeHtmlEnhancements from '../rehype-html-enhancements';
+
+async function processWithRawHtml(html: string) {
+  const result = await unified()
+    .use(remarkParse)
+    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(rehypeRaw)
+    .use(rehypeHtmlEnhancements, {})
+    .use(rehypeStringify)
+    .process(html);
+
+  return String(result);
+}
+
+describe('rehypeHtmlEnhancements', () => {
+  it('adds target and rel for external links without explicit target', async () => {
+    const html = await processWithRawHtml(
+      '<a href="https://example.com">External</a>',
+    );
+
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+  });
+
+  it('respects author-defined target for external links', async () => {
+    const html = await processWithRawHtml(
+      '<a href="https://example.com" target="_self">External</a>',
+    );
+
+    expect(html).toContain('target="_self"');
+    expect(html).not.toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+  });
+});

--- a/apps/flowershow/lib/rehype-html-enhancements.ts
+++ b/apps/flowershow/lib/rehype-html-enhancements.ts
@@ -24,7 +24,11 @@ const rehypeHtmlEnhancements = (options: Options) => {
         // Check if the link is external (starts with http:// or https://)
         if (/^https?:\/\//i.test(href)) {
           node.properties = node.properties || {};
-          node.properties.target = '_blank';
+
+          if (!node.properties.target) {
+            node.properties.target = '_blank';
+          }
+
           node.properties.rel = 'noopener noreferrer';
         }
       }


### PR DESCRIPTION
## Summary
- preserve author-defined `target` on external raw HTML links in `rehypeHtmlEnhancements`
- continue adding `target="_blank"` only when no target is provided
- add unit tests covering default behavior and explicit target preservation

## Testing
- `corepack pnpm exec vitest run --project=unit lib/__tests__/rehype-html-enhancements.test.ts`

Fixes #1123
