### PR TITLE
fix(domain): display Vercel-provided CNAME target in custom domain form

### DIFF
--- a/apps/flowershow/components/dashboard/form/domain-configuration.tsx
+++ b/apps/flowershow/components/dashboard/form/domain-configuration.tsx
@@ -39,6 +39,9 @@ export default function DomainConfiguration({ domain }: { domain: string }) {
       domainJson.verification.find((x: any) => x.type === 'TXT')) ||
     null;
 
+  const cnameVerification =
+    domainJson.verification.find((x: any) => x.type === 'CNAME') || null;
+
   return (
     <div className="border-t border-stone-200 px-10 pb-5 pt-7 ">
       <div className="mb-4 flex items-center space-x-2">
@@ -147,7 +150,8 @@ export default function DomainConfiguration({ domain }: { domain: string }) {
                 <p className="mt-2 font-mono text-sm">
                   {recordType === 'A'
                     ? `76.76.21.21`
-                    : `cname.${env.NEXT_PUBLIC_DNS_DOMAIN}.`}
+                    : (cnameVerification?.value ??
+                      `cname.${env.NEXT_PUBLIC_DNS_DOMAIN}.`)}
                 </p>
               </div>
               <div>


### PR DESCRIPTION
## Summary
- use the CNAME verification value returned by Vercel when available
- keep the existing default CNAME value as a fallback
- ensure the custom-domain form can surface newer per-domain unique CNAME targets

## Testing
- npx -y @biomejs/biome check apps/flowershow/components/dashboard/form/domain-configuration.tsx
  - reports two pre-existing `==` lint warnings in this file (unchanged by this PR)

Fixes #1126