### PR TITLE
fix(theme): use CSS custom properties for nav CTA button

### DIFF
--- a/apps/flowershow/styles/default-theme.css
+++ b/apps/flowershow/styles/default-theme.css
@@ -101,6 +101,11 @@
 
     --color-accent-lighter: oklch(from var(--color-accent) calc(l + 0.15) c h);
     --color-accent-darker: oklch(from var(--color-accent) calc(l - 0.1) c h);
+
+    /* CTA BUTTON (override in theme to customize nav call-to-action) */
+    /* --color-cta-bg:        default = --color-foreground-700 */
+    /* --color-cta-bg-hover:  default = --color-foreground-500 */
+    /* --color-cta-text:      default = #ffffff               */
   }
 
   :root[data-theme="dark"] {
@@ -376,16 +381,17 @@
   .site-navbar-cta-button,
   .mobile-nav-cta-button {
     border-radius: 0.375rem;
-    background-color: var(--color-foreground-700);
+    background-color: var(--color-cta-bg, var(--color-foreground-700));
     padding: 0.375rem 0.625rem;
     font-size: 0.875rem;
     line-height: 1.25rem;
     font-weight: 600;
-    color: #ffffff;
+    color: var(--color-cta-text, #ffffff);
     box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
 
     &:hover {
-      background-color: var(--color-foreground-500);
+      background-color: var(--color-cta-bg-hover, var(--color-foreground-500));
+      color: var(--color-cta-text, #ffffff);
     }
   }
   .site-navbar-cta-button {


### PR DESCRIPTION
## Summary

- Replaces hardcoded `color` and `background-color` values on `.site-navbar-cta-button` / `.mobile-nav-cta-button` with CSS custom properties (`--color-cta-bg`, `--color-cta-text`, `--color-cta-bg-hover`) that fall back to the existing defaults
- Adds explicit `color` on `:hover` so the text color is preserved during hover state
- Documents the new custom properties in the `:root` design-tokens section

## Problem

Themes like "Leaf" use broad selectors (e.g. `.site-navbar *`) to set navbar text color. Because theme CSS is unlayered and loaded after the default theme (which uses `@layer components`), the theme's wildcard rule overrides the CTA button's `color: #ffffff`, making the button text invisible or unreadable against its background.

See: https://github.com/flowershow/flowershow/issues/1207

## Solution

By exposing CTA colors as CSS custom properties, theme authors can control the CTA appearance by setting `--color-cta-text`, `--color-cta-bg`, and `--color-cta-bg-hover` in their `:root` block instead of relying on broad wildcard selectors that unintentionally break the button.

For the Leaf theme specifically, adding these three lines to `theme.css` fixes the issue:
```css
:root {
  --color-cta-bg: var(--color-primary);
  --color-cta-bg-hover: #2a2a06;
  --color-cta-text: #ffffff;
}
```

## Test plan

- [ ] Verify CTA button renders correctly with the default theme (no visual change expected)
- [ ] Verify CTA button renders correctly with the Leaf theme when `--color-cta-text` is set in the theme's `:root`
- [ ] Verify hover state preserves text color

Fixes #1207

🤖 Generated with [Claude Code](https://claude.com/claude-code)