### PR TITLE
feat: knowledge graph panel

### DIFF
--- a/apps/flowershow/app/(cloud)/dashboard/site/[id]/settings/page.tsx
+++ b/apps/flowershow/app/(cloud)/dashboard/site/[id]/settings/page.tsx
@@ -688,6 +688,16 @@ export default async function SiteSettingsPage(props: {
             }}
             handleSubmit={updateDbConfig}
           />
+          <Form
+            title="Show Knowledge Graph"
+            description="Show a knowledge graph on each page, visualising connections between notes."
+            inputAttrs={{
+              name: 'showKnowledgeGraph',
+              type: 'text',
+              defaultValue: (siteConfig?.showKnowledgeGraph ?? true).toString(),
+            }}
+            handleSubmit={updateDbConfig}
+          />
           <JsonForm
             title="Content Include"
             description="Paths to include in the site (e.g. directories or specific files). Leave empty to include everything."

--- a/apps/flowershow/app/(public)/site/[user]/[project]/[[...slug]]/_components/graph-view.tsx
+++ b/apps/flowershow/app/(public)/site/[user]/[project]/[[...slug]]/_components/graph-view.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { api } from '@/trpc/react';
+
+const ForceGraph2D = dynamic(() => import('react-force-graph-2d'), {
+  ssr: false,
+});
+
+interface GraphNode {
+  id: string;
+  appPath: string;
+  title?: string;
+  fx?: number;
+  fy?: number;
+}
+
+// After the library initialises, source/target are resolved to node objects.
+interface GraphLink {
+  source: string | GraphNode;
+  target: string | GraphNode;
+}
+
+interface Props {
+  siteId: string;
+  currentBlobId: string;
+}
+
+const MINI_WIDTH = 220;
+const MINI_HEIGHT = 160;
+const FULL_WIDTH = 800;
+const FULL_HEIGHT = 600;
+
+const NODE_COLOR_DEFAULT = '#94a3b8';
+const NODE_COLOR_DEFAULT_DIM = 'rgba(148, 163, 184, 0.15)';
+const NODE_COLOR_CURRENT = '#f97316';
+const NODE_COLOR_CURRENT_DIM = 'rgba(249, 115, 22, 0.15)';
+const LINK_COLOR = '#cbd5e1';
+const LINK_COLOR_DIM = 'rgba(203, 213, 225, 0.1)';
+const NODE_LABEL_COLOR = '#334155';
+const NODE_LABEL_COLOR_DIM = 'rgba(51, 65, 85, 0.15)';
+
+const MINI_NODE_REL_SIZE = 3;
+const FULL_NODE_REL_SIZE = 5;
+
+function asNode(n: unknown): GraphNode {
+  return n as GraphNode;
+}
+
+function getLinkEndId(end: unknown): string {
+  if (typeof end === 'string') return end;
+  if (end && typeof end === 'object' && 'id' in end)
+    return (end as { id: string }).id;
+  return '';
+}
+
+// Painters are stable references that read hover state via a ref getter to
+// avoid recreating them on every hover change.
+function makeNodeLabelPainter(
+  nodeRelSize: number,
+  maxLen: number,
+  getHighlightedIds: () => Set<string> | null,
+) {
+  return (n: unknown, ctx: CanvasRenderingContext2D, globalScale: number) => {
+    const node = asNode(n) as GraphNode & { x: number; y: number };
+    const raw = node.title ?? node.appPath.split('/').pop() ?? '';
+    const label = raw.length > maxLen ? `${raw.slice(0, maxLen)}…` : raw;
+    if (!label) return;
+    const fontSize = Math.max(4, 12 / globalScale);
+    ctx.font = `${fontSize}px Sans-Serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    const highlightedIds = getHighlightedIds();
+    const dimmed = highlightedIds !== null && !highlightedIds.has(node.id);
+    ctx.fillStyle = dimmed ? NODE_LABEL_COLOR_DIM : NODE_LABEL_COLOR;
+    ctx.fillText(label, node.x, node.y + nodeRelSize + 2 / globalScale);
+  };
+}
+
+const nodeLabelMode = () => 'after';
+
+export default function GraphMiniPanel({ siteId, currentBlobId }: Props) {
+  const router = useRouter();
+  const [modalOpen, setModalOpen] = useState(false);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
+  const highlightedNodeIdsRef = useRef<Set<string> | null>(null);
+
+  const { data, isLoading, error } = api.site.getGraphData.useQuery({ siteId });
+
+  const graphData = useMemo(
+    () => ({
+      nodes: ((data?.nodes ?? []) as GraphNode[]).map((n) =>
+        n.id === currentBlobId ? { ...n, fx: 0, fy: 0 } : n,
+      ),
+      links: (data?.links ?? []) as GraphLink[],
+    }),
+    [data, currentBlobId],
+  );
+
+  // Hovered node + its direct neighbours. null means no hover (nothing dimmed).
+  const highlightedNodeIds = useMemo(() => {
+    if (!hoveredNodeId) return null;
+    const ids = new Set<string>([hoveredNodeId]);
+    for (const link of graphData.links) {
+      const src = getLinkEndId(link.source);
+      const tgt = getLinkEndId(link.target);
+      if (src === hoveredNodeId || tgt === hoveredNodeId) {
+        ids.add(src);
+        ids.add(tgt);
+      }
+    }
+    return ids;
+  }, [hoveredNodeId, graphData.links]);
+
+  // Keep ref in sync so the stable canvas painters always see the latest set.
+  useEffect(() => {
+    highlightedNodeIdsRef.current = highlightedNodeIds;
+  }, [highlightedNodeIds]);
+
+  const paintMiniLabel = useMemo(
+    () =>
+      makeNodeLabelPainter(
+        MINI_NODE_REL_SIZE,
+        12,
+        () => highlightedNodeIdsRef.current,
+      ),
+    [],
+  );
+
+  const paintFullLabel = useMemo(
+    () =>
+      makeNodeLabelPainter(
+        FULL_NODE_REL_SIZE,
+        30,
+        () => highlightedNodeIdsRef.current,
+      ),
+    [],
+  );
+
+  const nodeColor = useCallback(
+    (n: unknown) => {
+      const node = asNode(n);
+      const isCurrent = node.id === currentBlobId;
+      if (highlightedNodeIds !== null && !highlightedNodeIds.has(node.id)) {
+        return isCurrent ? NODE_COLOR_CURRENT_DIM : NODE_COLOR_DEFAULT_DIM;
+      }
+      return isCurrent ? NODE_COLOR_CURRENT : NODE_COLOR_DEFAULT;
+    },
+    [currentBlobId, highlightedNodeIds],
+  );
+
+  const linkColor = useCallback(
+    (link: unknown) => {
+      if (!highlightedNodeIds) return LINK_COLOR;
+      const l = link as GraphLink;
+      const src = getLinkEndId(l.source);
+      const tgt = getLinkEndId(l.target);
+      return highlightedNodeIds.has(src) && highlightedNodeIds.has(tgt)
+        ? LINK_COLOR
+        : LINK_COLOR_DIM;
+    },
+    [highlightedNodeIds],
+  );
+
+  const handleNodeHover = useCallback((n: unknown) => {
+    setHoveredNodeId(n ? asNode(n).id : null);
+  }, []);
+
+  const handleNodeClick = useCallback(
+    (n: unknown) => {
+      const node = asNode(n);
+      if (node.appPath) {
+        setModalOpen(false);
+        router.push(node.appPath);
+      }
+    },
+    [router],
+  );
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (modalOpen) {
+      dialog.showModal();
+    } else {
+      dialog.close();
+    }
+  }, [modalOpen]);
+
+  const handleDialogClick = useCallback(
+    (e: React.MouseEvent<HTMLDialogElement>) => {
+      if (e.target === dialogRef.current) setModalOpen(false);
+    },
+    [],
+  );
+
+  if (isLoading) {
+    return <div className="graph-mini-panel graph-mini-panel--loading" />;
+  }
+
+  if (error || !data) return null;
+
+  return (
+    <>
+      <div className="graph-mini-panel">
+        <ForceGraph2D
+          graphData={graphData}
+          width={MINI_WIDTH}
+          height={MINI_HEIGHT}
+          nodeId="id"
+          nodeColor={nodeColor}
+          nodeCanvasObject={paintMiniLabel}
+          nodeCanvasObjectMode={nodeLabelMode}
+          linkColor={linkColor}
+          nodeRelSize={MINI_NODE_REL_SIZE}
+          onNodeClick={handleNodeClick}
+          onNodeHover={handleNodeHover}
+        />
+        <button
+          type="button"
+          className="graph-mini-panel__expand"
+          aria-label="Expand knowledge graph"
+          onClick={() => setModalOpen(true)}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <polyline points="15 3 21 3 21 9" />
+            <polyline points="9 21 3 21 3 15" />
+            <line x1="21" y1="3" x2="14" y2="10" />
+            <line x1="3" y1="21" x2="10" y2="14" />
+          </svg>
+        </button>
+      </div>
+
+      <dialog
+        ref={dialogRef}
+        className="graph-modal"
+        onClick={handleDialogClick}
+        onClose={() => setModalOpen(false)}
+      >
+        <div className="graph-modal__inner">
+          <div className="graph-modal__header">
+            <span className="graph-modal__title">Knowledge graph</span>
+            <button
+              className="graph-modal__close"
+              aria-label="Close"
+              onClick={() => setModalOpen(false)}
+            >
+              ✕
+            </button>
+          </div>
+          <ForceGraph2D
+            graphData={graphData}
+            width={FULL_WIDTH}
+            height={FULL_HEIGHT}
+            nodeId="id"
+            nodeColor={nodeColor}
+            nodeCanvasObject={paintFullLabel}
+            nodeCanvasObjectMode={nodeLabelMode}
+            linkColor={linkColor}
+            nodeRelSize={FULL_NODE_REL_SIZE}
+            onNodeClick={handleNodeClick}
+            onNodeHover={handleNodeHover}
+          />
+        </div>
+      </dialog>
+    </>
+  );
+}

--- a/apps/flowershow/app/(public)/site/[user]/[project]/[[...slug]]/_components/graph-view.tsx
+++ b/apps/flowershow/app/(public)/site/[user]/[project]/[[...slug]]/_components/graph-view.tsx
@@ -88,7 +88,10 @@ export default function GraphMiniPanel({ siteId, currentBlobId }: Props) {
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const highlightedNodeIdsRef = useRef<Set<string> | null>(null);
 
-  const { data, isLoading, error } = api.site.getGraphData.useQuery({ siteId });
+  const { data, isLoading, error } = api.site.getGraphData.useQuery({
+    siteId,
+    blobId: currentBlobId,
+  });
 
   const graphData = useMemo(
     () => ({

--- a/apps/flowershow/app/(public)/site/[user]/[project]/[[...slug]]/_components/graph-view.tsx
+++ b/apps/flowershow/app/(public)/site/[user]/[project]/[[...slug]]/_components/graph-view.tsx
@@ -28,19 +28,34 @@ interface Props {
   currentBlobId: string;
 }
 
-const MINI_WIDTH = 220;
-const MINI_HEIGHT = 160;
-const FULL_WIDTH = 800;
-const FULL_HEIGHT = 600;
+const MINI_WIDTH = 240;
+const MINI_HEIGHT = 180;
+const FULL_WIDTH = 900;
+const FULL_HEIGHT = 700;
 
 const NODE_COLOR_DEFAULT = '#94a3b8';
-const NODE_COLOR_DEFAULT_DIM = 'rgba(148, 163, 184, 0.15)';
 const NODE_COLOR_CURRENT = '#f97316';
-const NODE_COLOR_CURRENT_DIM = 'rgba(249, 115, 22, 0.15)';
 const LINK_COLOR = '#cbd5e1';
-const LINK_COLOR_DIM = 'rgba(203, 213, 225, 0.1)';
 const NODE_LABEL_COLOR = '#334155';
-const NODE_LABEL_COLOR_DIM = 'rgba(51, 65, 85, 0.15)';
+
+// RGB tuples for alpha interpolation during hover transitions
+const NODE_DEFAULT_RGB = [148, 163, 184] as const;
+const NODE_CURRENT_RGB = [249, 115, 22] as const;
+const LINK_RGB = [203, 213, 225] as const;
+const LABEL_RGB = [51, 65, 85] as const;
+const DIM_ALPHA = 0.15;
+const LINK_DIM_ALPHA = 0.1;
+
+const TRANSITION_DURATION = 180; // ms
+
+function dimmedColor(
+  rgb: readonly [number, number, number],
+  progress: number,
+  targetAlpha: number,
+): string {
+  const alpha = 1 - progress * (1 - targetAlpha);
+  return `rgba(${rgb[0]}, ${rgb[1]}, ${rgb[2]}, ${alpha.toFixed(3)})`;
+}
 
 const MINI_NODE_REL_SIZE = 3;
 const FULL_NODE_REL_SIZE = 5;
@@ -56,25 +71,33 @@ function getLinkEndId(end: unknown): string {
   return '';
 }
 
-// Painters are stable references that read hover state via a ref getter to
+// Painters are stable references that read hover state via ref getters to
 // avoid recreating them on every hover change.
 function makeNodeLabelPainter(
   nodeRelSize: number,
   maxLen: number,
   getHighlightedIds: () => Set<string> | null,
+  getDimProgress: () => number,
+  getHoveredId: () => string | null,
 ) {
   return (n: unknown, ctx: CanvasRenderingContext2D, globalScale: number) => {
     const node = asNode(n) as GraphNode & { x: number; y: number };
     const raw = node.title ?? node.appPath.split('/').pop() ?? '';
     const label = raw.length > maxLen ? `${raw.slice(0, maxLen)}…` : raw;
     if (!label) return;
-    const fontSize = Math.max(4, 12 / globalScale);
+    const dp = getDimProgress();
+    const isHovered = getHoveredId() === node.id;
+    const fontScale = isHovered ? 1 + 0.1 * dp : 1;
+    const fontSize = Math.max(4, 12 / globalScale) * fontScale;
     ctx.font = `${fontSize}px Sans-Serif`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'top';
     const highlightedIds = getHighlightedIds();
-    const dimmed = highlightedIds !== null && !highlightedIds.has(node.id);
-    ctx.fillStyle = dimmed ? NODE_LABEL_COLOR_DIM : NODE_LABEL_COLOR;
+    const isDimmed = highlightedIds !== null && !highlightedIds.has(node.id);
+    ctx.fillStyle =
+      !isDimmed || dp === 0
+        ? NODE_LABEL_COLOR
+        : dimmedColor(LABEL_RGB, dp, DIM_ALPHA);
     ctx.fillText(label, node.x, node.y + nodeRelSize + 2 / globalScale);
   };
 }
@@ -86,7 +109,15 @@ export default function GraphMiniPanel({ siteId, currentBlobId }: Props) {
   const [modalOpen, setModalOpen] = useState(false);
   const dialogRef = useRef<HTMLDialogElement>(null);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
+  // renderHighlightedIds lags behind hoveredNodeId during fade-out so the
+  // dimming stays visible until the animation completes.
+  const [renderHighlightedIds, setRenderHighlightedIds] =
+    useState<Set<string> | null>(null);
+  const [dimProgress, setDimProgress] = useState(0);
+  const dimProgressRef = useRef(0);
   const highlightedNodeIdsRef = useRef<Set<string> | null>(null);
+  const hoveredNodeIdRef = useRef<string | null>(null);
+  const animFrameRef = useRef<number | null>(null);
 
   const { data, isLoading, error } = api.site.getGraphData.useQuery({
     siteId,
@@ -118,10 +149,47 @@ export default function GraphMiniPanel({ siteId, currentBlobId }: Props) {
     return ids;
   }, [hoveredNodeId, graphData.links]);
 
-  // Keep ref in sync so the stable canvas painters always see the latest set.
+  // Animate dimProgress when hover changes. renderHighlightedIds is kept alive
+  // during fade-out so the dimming remains visible until the transition ends.
   useEffect(() => {
-    highlightedNodeIdsRef.current = highlightedNodeIds;
-  }, [highlightedNodeIds]);
+    const target = highlightedNodeIds !== null ? 1 : 0;
+
+    if (highlightedNodeIds !== null) {
+      setRenderHighlightedIds(highlightedNodeIds);
+      highlightedNodeIdsRef.current = highlightedNodeIds;
+      hoveredNodeIdRef.current = hoveredNodeId;
+    }
+
+    if (animFrameRef.current !== null)
+      cancelAnimationFrame(animFrameRef.current);
+
+    const startValue = dimProgressRef.current;
+    if (startValue === target) return;
+
+    const startTime = performance.now();
+
+    function tick(now: number) {
+      const elapsed = now - startTime;
+      const t = Math.min(elapsed / TRANSITION_DURATION, 1);
+      const eased = t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2;
+      const value = startValue + (target - startValue) * eased;
+      dimProgressRef.current = value;
+      setDimProgress(value);
+      if (t < 1) {
+        animFrameRef.current = requestAnimationFrame(tick);
+      } else if (target === 0) {
+        setRenderHighlightedIds(null);
+        highlightedNodeIdsRef.current = null;
+        hoveredNodeIdRef.current = null;
+      }
+    }
+
+    animFrameRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (animFrameRef.current !== null)
+        cancelAnimationFrame(animFrameRef.current);
+    };
+  }, [highlightedNodeIds, hoveredNodeId]);
 
   const paintMiniLabel = useMemo(
     () =>
@@ -129,6 +197,8 @@ export default function GraphMiniPanel({ siteId, currentBlobId }: Props) {
         MINI_NODE_REL_SIZE,
         12,
         () => highlightedNodeIdsRef.current,
+        () => dimProgressRef.current,
+        () => hoveredNodeIdRef.current,
       ),
     [],
   );
@@ -139,6 +209,8 @@ export default function GraphMiniPanel({ siteId, currentBlobId }: Props) {
         FULL_NODE_REL_SIZE,
         30,
         () => highlightedNodeIdsRef.current,
+        () => dimProgressRef.current,
+        () => hoveredNodeIdRef.current,
       ),
     [],
   );
@@ -147,25 +219,31 @@ export default function GraphMiniPanel({ siteId, currentBlobId }: Props) {
     (n: unknown) => {
       const node = asNode(n);
       const isCurrent = node.id === currentBlobId;
-      if (highlightedNodeIds !== null && !highlightedNodeIds.has(node.id)) {
-        return isCurrent ? NODE_COLOR_CURRENT_DIM : NODE_COLOR_DEFAULT_DIM;
+      const isDimmed =
+        renderHighlightedIds !== null && !renderHighlightedIds.has(node.id);
+      if (!isDimmed || dimProgress === 0) {
+        return isCurrent ? NODE_COLOR_CURRENT : NODE_COLOR_DEFAULT;
       }
-      return isCurrent ? NODE_COLOR_CURRENT : NODE_COLOR_DEFAULT;
+      return dimmedColor(
+        isCurrent ? NODE_CURRENT_RGB : NODE_DEFAULT_RGB,
+        dimProgress,
+        DIM_ALPHA,
+      );
     },
-    [currentBlobId, highlightedNodeIds],
+    [currentBlobId, renderHighlightedIds, dimProgress],
   );
 
   const linkColor = useCallback(
     (link: unknown) => {
-      if (!highlightedNodeIds) return LINK_COLOR;
+      if (!renderHighlightedIds || dimProgress === 0) return LINK_COLOR;
       const l = link as GraphLink;
       const src = getLinkEndId(l.source);
       const tgt = getLinkEndId(l.target);
-      return highlightedNodeIds.has(src) && highlightedNodeIds.has(tgt)
-        ? LINK_COLOR
-        : LINK_COLOR_DIM;
+      if (renderHighlightedIds.has(src) && renderHighlightedIds.has(tgt))
+        return LINK_COLOR;
+      return dimmedColor(LINK_RGB, dimProgress, LINK_DIM_ALPHA);
     },
-    [highlightedNodeIds],
+    [renderHighlightedIds, dimProgress],
   );
 
   const handleNodeHover = useCallback((n: unknown) => {
@@ -256,7 +334,6 @@ export default function GraphMiniPanel({ siteId, currentBlobId }: Props) {
       >
         <div className="graph-modal__inner">
           <div className="graph-modal__header">
-            <span className="graph-modal__title">Knowledge graph</span>
             <button
               className="graph-modal__close"
               aria-label="Close"
@@ -265,19 +342,21 @@ export default function GraphMiniPanel({ siteId, currentBlobId }: Props) {
               ✕
             </button>
           </div>
-          <ForceGraph2D
-            graphData={graphData}
-            width={FULL_WIDTH}
-            height={FULL_HEIGHT}
-            nodeId="id"
-            nodeColor={nodeColor}
-            nodeCanvasObject={paintFullLabel}
-            nodeCanvasObjectMode={nodeLabelMode}
-            linkColor={linkColor}
-            nodeRelSize={FULL_NODE_REL_SIZE}
-            onNodeClick={handleNodeClick}
-            onNodeHover={handleNodeHover}
-          />
+          {modalOpen && (
+            <ForceGraph2D
+              graphData={graphData}
+              width={FULL_WIDTH}
+              height={FULL_HEIGHT}
+              nodeId="id"
+              nodeColor={nodeColor}
+              nodeCanvasObject={paintFullLabel}
+              nodeCanvasObjectMode={nodeLabelMode}
+              linkColor={linkColor}
+              nodeRelSize={FULL_NODE_REL_SIZE}
+              onNodeClick={handleNodeClick}
+              onNodeHover={handleNodeHover}
+            />
+          )}
         </div>
       </dialog>
     </>

--- a/apps/flowershow/app/(public)/site/[user]/[project]/[[...slug]]/page.tsx
+++ b/apps/flowershow/app/(public)/site/[user]/[project]/[[...slug]]/page.tsx
@@ -33,6 +33,7 @@ import { ensureLeadingSlash } from '@/lib/utils';
 import type { PageMetadata } from '@/server/api/types';
 import { api } from '@/trpc/server';
 import BacklinksPanel from './_components/backlinks-panel';
+import GraphMiniPanel from './_components/graph-view';
 import UrlNormalizer from './_components/url-normalizer';
 
 const config = getConfig();
@@ -515,6 +516,7 @@ export default async function SitePage(props: {
 
         {showToc && (
           <div className="layout-inner-right">
+            <GraphMiniPanel siteId={site.id} currentBlobId={blob.id} />
             <aside className="page-toc-container">
               <TableOfContents />
             </aside>

--- a/apps/flowershow/app/(public)/site/[user]/[project]/[[...slug]]/page.tsx
+++ b/apps/flowershow/app/(public)/site/[user]/[project]/[[...slug]]/page.tsx
@@ -401,6 +401,9 @@ export default async function SitePage(props: {
     return activeSidebarPath !== undefined;
   })();
   const showToc = metadata?.showToc ?? siteConfig?.showToc;
+  const showKnowledgeGraph =
+    metadata?.showKnowledgeGraph ?? siteConfig?.showKnowledgeGraph ?? true;
+  const showRightColumn = showToc || showKnowledgeGraph;
   const heroConfig = resolveHeroConfig(metadata, siteConfig);
   const showHero = heroConfig.showHero;
 
@@ -446,9 +449,9 @@ export default async function SitePage(props: {
       <div
         className={clsx(
           'layout-inner',
-          showSidebar && showToc && 'has-sidebar-and-toc',
-          !showSidebar && showToc && 'has-toc',
-          showSidebar && !showToc && 'has-sidebar',
+          showSidebar && showRightColumn && 'has-sidebar-and-toc',
+          !showSidebar && showRightColumn && 'has-toc',
+          showSidebar && !showRightColumn && 'has-sidebar',
         )}
       >
         {showSidebar && (
@@ -514,12 +517,16 @@ export default async function SitePage(props: {
           )}
         </div>
 
-        {showToc && (
+        {showRightColumn && (
           <div className="layout-inner-right">
-            <GraphMiniPanel siteId={site.id} currentBlobId={blob.id} />
-            <aside className="page-toc-container">
-              <TableOfContents />
-            </aside>
+            {showKnowledgeGraph && (
+              <GraphMiniPanel siteId={site.id} currentBlobId={blob.id} />
+            )}
+            {showToc && (
+              <aside className="page-toc-container">
+                <TableOfContents />
+              </aside>
+            )}
           </div>
         )}
       </div>

--- a/apps/flowershow/components/dashboard/form/index.tsx
+++ b/apps/flowershow/components/dashboard/form/index.tsx
@@ -61,6 +61,7 @@ export default function Form({
     'showEditLink',
     'showModeSwitch',
     'showBacklinks',
+    'showKnowledgeGraph',
   ].includes(inputAttrs.name);
 
   // Controlled value for all non-toggle inputs (text, textarea, select)

--- a/apps/flowershow/components/public/footer.tsx
+++ b/apps/flowershow/components/public/footer.tsx
@@ -71,11 +71,12 @@ export default async function Footer({
             </p>
             {social && (
               <div className="site-footer-social-links">
-                {social.map(({ label, href }, index) => {
+                {social.map(({ label, href }) => {
+                  if (!href) return null;
                   const Icon = (label && socialIcons[label]) || GlobeIcon;
                   return (
                     <Link
-                      key={`${href}-${index}`}
+                      key={href}
                       href={href}
                       target="_blank"
                       rel="noopener noreferrer"

--- a/apps/flowershow/components/public/nav.tsx
+++ b/apps/flowershow/components/public/nav.tsx
@@ -119,11 +119,12 @@ const Nav = ({
             )}
             {social && (
               <div className="site-navbar-social-links-container">
-                {social.map(({ label, href }, index) => {
+                {social.map(({ label, href }) => {
+                  if (!href) return null;
                   const Icon = (label && socialIcons[label]) || GlobeIcon;
                   return (
                     <a
-                      key={`${href}-${index}`}
+                      key={href}
                       href={href}
                       target="_blank"
                       rel="noopener noreferrer"
@@ -208,17 +209,20 @@ const Nav = ({
             {social && (
               <div className="mobile-nav-social-links-container">
                 {social &&
-                  social.map(({ label, name, href }, index) => (
-                    <a
-                      key={`${href}-${index}`}
-                      href={href}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="mobile-nav-social-link"
-                    >
-                      {name}
-                    </a>
-                  ))}
+                  social.map(({ label, name, href }) => {
+                    if (!href) return null;
+                    return (
+                      <a
+                        key={href}
+                        href={href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="mobile-nav-social-link"
+                      >
+                        {name}
+                      </a>
+                    );
+                  })}
               </div>
             )}
             {cta && (

--- a/apps/flowershow/components/types.ts
+++ b/apps/flowershow/components/types.ts
@@ -81,6 +81,7 @@ export interface SiteConfig {
     paths?: string[];
   };
   showToc?: boolean;
+  showKnowledgeGraph?: boolean;
   showEditLink?: boolean;
   showComments?: boolean;
   showBacklinks?: boolean;

--- a/apps/flowershow/lib/site-config.ts
+++ b/apps/flowershow/lib/site-config.ts
@@ -11,6 +11,7 @@ function normalizeUmamiConfig(
 
 export const SITE_CONFIG_DEFAULTS = {
   showToc: true,
+  showKnowledgeGraph: true,
   showSidebar: true,
   showComments: false,
   showBacklinks: true,

--- a/apps/flowershow/package.json
+++ b/apps/flowershow/package.json
@@ -87,6 +87,7 @@
     "react": "19.2.1",
     "react-dom": "19.2.1",
     "react-error-boundary": "^6.0.0",
+    "react-force-graph-2d": "^1.29.1",
     "react-instantsearch": "^7.16.3",
     "react-leaflet": "^5.0.0",
     "react-loading-skeleton": "^3.5.0",

--- a/apps/flowershow/server/api/routers/site.ts
+++ b/apps/flowershow/server/api/routers/site.ts
@@ -2049,6 +2049,57 @@ export const siteRouter = createTRPCRouter({
         },
       )(input);
     }),
+  getGraphData: publicProcedure
+    .input(
+      z.object({
+        siteId: z.string().min(1),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const siteForAccess = await ctx.db.site.findUnique({
+        where: { id: input.siteId },
+        select: { privacyMode: true, tokenVersion: true, userId: true },
+      });
+      await assertSiteAccess(siteForAccess, input.siteId, ctx);
+
+      return await unstable_cache(
+        async (input) => {
+          const [blobs, links] = await Promise.all([
+            ctx.db.blob.findMany({
+              where: { siteId: input.siteId, appPath: { not: null } },
+              select: { id: true, appPath: true, metadata: true },
+            }),
+            ctx.db.link.findMany({
+              where: { siteId: input.siteId, targetBlobId: { not: null } },
+              select: { sourceBlobId: true, targetBlobId: true },
+            }),
+          ]);
+
+          return {
+            nodes: blobs
+              .filter((b) => b.appPath !== null)
+              .map((b) => ({
+                id: b.id,
+                appPath: b.appPath as string,
+                title: (b.metadata as Record<string, unknown> | null)?.title as
+                  | string
+                  | undefined,
+              })),
+            links: links
+              .filter((l) => l.targetBlobId !== null)
+              .map((l) => ({
+                source: l.sourceBlobId,
+                target: l.targetBlobId as string,
+              })),
+          };
+        },
+        undefined,
+        {
+          revalidate: 60,
+          tags: [`${input.siteId}`],
+        },
+      )(input);
+    }),
 });
 
 // ---- Util: ensure unique project name per user ----

--- a/apps/flowershow/server/api/routers/site.ts
+++ b/apps/flowershow/server/api/routers/site.ts
@@ -2053,6 +2053,7 @@ export const siteRouter = createTRPCRouter({
     .input(
       z.object({
         siteId: z.string().min(1),
+        blobId: z.string().min(1),
       }),
     )
     .query(async ({ ctx, input }) => {
@@ -2064,28 +2065,63 @@ export const siteRouter = createTRPCRouter({
 
       return await unstable_cache(
         async (input) => {
-          const [blobs, links] = await Promise.all([
+          const directLinks = await ctx.db.link.findMany({
+            where: {
+              siteId: input.siteId,
+              targetBlobId: { not: null },
+              OR: [
+                { sourceBlobId: input.blobId },
+                { targetBlobId: input.blobId },
+              ],
+            },
+            select: { sourceBlobId: true, targetBlobId: true },
+          });
+
+          const neighborIds = new Set<string>([input.blobId]);
+          for (const l of directLinks) {
+            neighborIds.add(l.sourceBlobId);
+            if (l.targetBlobId) neighborIds.add(l.targetBlobId);
+          }
+
+          const neighborIdList = [...neighborIds];
+
+          const [blobs, interLinks] = await Promise.all([
             ctx.db.blob.findMany({
-              where: { siteId: input.siteId, appPath: { not: null } },
+              where: { id: { in: neighborIdList }, appPath: { not: null } },
               select: { id: true, appPath: true, metadata: true },
             }),
             ctx.db.link.findMany({
-              where: { siteId: input.siteId, targetBlobId: { not: null } },
+              where: {
+                siteId: input.siteId,
+                targetBlobId: { not: null },
+                sourceBlobId: { in: neighborIdList },
+                AND: [{ targetBlobId: { in: neighborIdList } }],
+              },
               select: { sourceBlobId: true, targetBlobId: true },
             }),
           ]);
 
+          const allLinks = [
+            ...directLinks,
+            ...interLinks.filter(
+              (il) =>
+                !directLinks.some(
+                  (dl) =>
+                    dl.sourceBlobId === il.sourceBlobId &&
+                    dl.targetBlobId === il.targetBlobId,
+                ),
+            ),
+          ];
+
           return {
-            nodes: blobs
-              .filter((b) => b.appPath !== null)
-              .map((b) => ({
-                id: b.id,
-                appPath: b.appPath as string,
-                title: (b.metadata as Record<string, unknown> | null)?.title as
-                  | string
-                  | undefined,
-              })),
-            links: links
+            nodes: blobs.map((b) => ({
+              id: b.id,
+              appPath: b.appPath as string,
+              title: (b.metadata as Record<string, unknown> | null)?.title as
+                | string
+                | undefined,
+            })),
+            links: allLinks
               .filter((l) => l.targetBlobId !== null)
               .map((l) => ({
                 source: l.sourceBlobId,
@@ -2096,7 +2132,7 @@ export const siteRouter = createTRPCRouter({
         undefined,
         {
           revalidate: 60,
-          tags: [`${input.siteId}`],
+          tags: [`${input.siteId}`, `${input.siteId}-graph-${input.blobId}`],
         },
       )(input);
     }),

--- a/apps/flowershow/server/api/types.ts
+++ b/apps/flowershow/server/api/types.ts
@@ -95,6 +95,7 @@ export interface PageMetadata {
   publish?: boolean;
   showSidebar?: boolean;
   showToc?: boolean;
+  showKnowledgeGraph?: boolean;
   showHero?: boolean;
   hero?:
     | boolean

--- a/apps/flowershow/styles/default-theme.css
+++ b/apps/flowershow/styles/default-theme.css
@@ -2294,6 +2294,112 @@
     padding-top: 2.5rem;
   }
 
+  /* ── Knowledge graph ───────────────────────────────── */
+  .graph-mini-panel {
+    position: relative;
+    border: 1px solid var(--color-foreground-200);
+    border-radius: 0.5rem;
+    overflow: hidden;
+    margin-bottom: 1rem;
+    background: var(--color-background);
+
+    canvas {
+      display: block;
+    }
+  }
+
+  .graph-mini-panel__expand {
+    position: absolute;
+    top: 0.375rem;
+    right: 0.375rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 0.25rem;
+    border: none;
+    background: var(--color-background);
+    color: var(--color-foreground-400);
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.15s;
+
+    &:hover {
+      color: var(--color-foreground-700);
+      background: var(--color-foreground-100);
+    }
+  }
+
+  .graph-mini-panel:hover .graph-mini-panel__expand {
+    opacity: 1;
+  }
+
+  .graph-mini-panel--loading {
+    height: 160px;
+    background: var(--color-foreground-100);
+    border-radius: 0.5rem;
+    margin-bottom: 1rem;
+  }
+
+  .graph-mini-panel__label {
+    font-family: var(--font-heading);
+    font-size: var(--font-size-sm);
+    color: var(--color-foreground-400);
+    text-align: center;
+    padding: 0.25rem 0 0.5rem;
+    margin: 0;
+  }
+
+  .graph-modal {
+    border: none;
+    border-radius: 0.75rem;
+    padding: 0;
+    max-width: 90vw;
+    max-height: 90vh;
+    overflow: hidden;
+    box-shadow: 0 20px 60px rgb(0 0 0 / 0.3);
+    background: var(--color-background);
+
+    &::backdrop {
+      background: rgb(0 0 0 / 0.5);
+    }
+  }
+
+  .graph-modal__inner {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .graph-modal__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--color-foreground-200);
+  }
+
+  .graph-modal__title {
+    font-family: var(--font-heading);
+    font-weight: var(--font-weight-semibold);
+    font-size: var(--font-size-base);
+    color: var(--color-foreground-700);
+  }
+
+  .graph-modal__close {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-foreground-400);
+    font-size: 1rem;
+    line-height: 1;
+    padding: 0.25rem;
+
+    &:hover {
+      color: var(--color-foreground-700);
+    }
+  }
+
   .visitor-logout-button {
     position: fixed;
     bottom: 1rem;

--- a/apps/flowershow/styles/default-theme.css
+++ b/apps/flowershow/styles/default-theme.css
@@ -794,7 +794,7 @@
     @media (min-width: 1280px) {
       /* xl */
       &.has-sidebar-and-toc {
-        grid-template-columns: 16rem minmax(0, 1fr) 12rem;
+        grid-template-columns: 16rem minmax(0, 1fr) 240px;
       }
     }
 
@@ -809,7 +809,7 @@
     @media (min-width: 1280px) {
       /* xl */
       &.has-toc {
-        grid-template-columns: minmax(0, 1fr) 12rem;
+        grid-template-columns: minmax(0, 1fr) 240px;
         padding-left: 16rem;
       }
     }
@@ -2296,6 +2296,7 @@
 
   /* ── Knowledge graph ───────────────────────────────── */
   .graph-mini-panel {
+    height: 180px;
     position: relative;
     border: 1px solid var(--color-foreground-200);
     border-radius: 0.5rem;
@@ -2336,7 +2337,6 @@
   }
 
   .graph-mini-panel--loading {
-    height: 160px;
     background: var(--color-foreground-100);
     border-radius: 0.5rem;
     margin-bottom: 1rem;

--- a/content/flowershow-app/changelog/2026-06-29-knowledge-graph.md
+++ b/content/flowershow-app/changelog/2026-06-29-knowledge-graph.md
@@ -1,0 +1,32 @@
+---
+title: "Knowledge Graph"
+date: 2026-06-29
+description: Every page now shows a live, interactive graph of how your notes connect — one of Obsidian's most beloved features, now on the web.
+authors:
+  - olayway
+showToc: false
+---
+
+If you've used Obsidian, you know the graph. A mini graph panel now appears on every page of your Flowershow site: the current note sits at the centre, highlighted in orange, with every connected note radiating outward. Hover a node to dim everything unrelated; click one to navigate to it. An expand button opens a full-size version in a modal for sites with dense link networks.
+
+## Why it's here now
+
+The graph needs a fast, queryable map of which page links to which. The [[2026-06-23-backlinks|backlinks feature]] shipped that infrastructure — a dedicated `Link` table that captures every wiki link, note embed, and CommonMark link during the publish pipeline. The graph is the second feature built on top of it.
+
+## Configuring it
+
+The graph is on by default. Turn it off site-wide in **Settings → Show Knowledge Graph**, via `config.json`:
+
+```json
+{
+  "showKnowledgeGraph": false
+}
+```
+
+or per page in frontmatter:
+
+```yaml
+---
+showKnowledgeGraph: false
+---
+```

--- a/content/flowershow-app/docs/reference/knowledge-graph.md
+++ b/content/flowershow-app/docs/reference/knowledge-graph.md
@@ -1,0 +1,45 @@
+---
+title: Knowledge Graph
+description: Show an interactive graph of how your notes connect to each other.
+---
+
+Configure the knowledge graph from the **Flowershow dashboard** under **Site Settings → Content**, or using `config.json` if you prefer to version-control your settings or manage them via an automated workflow.
+
+> [!note]
+> The knowledge graph is enabled by default and appears on the right-hand side of every page.
+
+## How the graph works
+
+During every publish, Flowershow extracts all internal links from your content and stores them. Three syntaxes are captured:
+
+- Wiki links: `[[Page Name]]`
+- Note embeds: `![[Page Name]]`
+- Standard Markdown links: `[text](path)`
+
+The graph renders these connections as a force-directed network. The current page is pinned at the centre and highlighted; every note that links to or from it radiates outward. Hover a node to dim unrelated nodes and links; click one to navigate to that page. An expand button opens a full-size view in a modal.
+
+## Show or hide the knowledge graph
+
+Go to **Settings → Content → Show Knowledge Graph** and set it to `true` or `false`.
+
+You can also override this on a per-page basis using frontmatter:
+
+```md
+---
+showKnowledgeGraph: false
+---
+
+Page content
+```
+
+## Using config.json
+
+If you want to version-control your configuration, or have your editor's AI agent manage settings without touching the dashboard, you can define everything in `config.json` instead. Values set in `config.json` take precedence over dashboard settings.
+
+```json
+{
+  "showKnowledgeGraph": false
+}
+```
+
+- `showKnowledgeGraph`: Set to `false` to disable the knowledge graph globally. Defaults to `true`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
       react-error-boundary:
         specifier: ^6.0.0
         version: 6.1.1(react@19.2.1)
+      react-force-graph-2d:
+        specifier: ^1.29.1
+        version: 1.29.1(react@19.2.1)
       react-instantsearch:
         specifier: ^7.16.3
         version: 7.23.2(algoliasearch@5.48.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -4555,6 +4558,10 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accessor-fn@1.5.3:
+    resolution: {integrity: sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==}
+    engines: {node: '>=12'}
+
   acorn-import-phases@1.0.4:
     resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
     engines: {node: '>=10.13.0'}
@@ -4914,6 +4921,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  bezier-js@6.1.4:
+    resolution: {integrity: sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==}
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -5031,6 +5041,10 @@ packages:
 
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+
+  canvas-color-tracker@1.3.2:
+    resolution: {integrity: sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==}
+    engines: {node: '>=12'}
 
   canvas-fit@1.5.0:
     resolution: {integrity: sha512-onIcjRpz69/Hx5bB5HGbYKUF2uC6QT6Gp+pfpGm3A7mPfcluSLV5v4Zu+oflDUwLdUw0rLIBhUbi0v8hM4FJQQ==}
@@ -5410,6 +5424,9 @@ packages:
     resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
     engines: {node: '>=12'}
 
+  d3-binarytree@1.0.2:
+    resolution: {integrity: sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==}
+
   d3-brush@2.1.0:
     resolution: {integrity: sha512-cHLLAFatBATyIKqZOkk/mDHUbzne2B3ZwxkzMHvFTCZCmLaXDpZRihQSn8UNXTkGD/3lb/W2sQz0etAftmHMJQ==}
 
@@ -5485,6 +5502,10 @@ packages:
     resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
     engines: {node: '>=12'}
 
+  d3-force-3d@3.0.6:
+    resolution: {integrity: sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==}
+    engines: {node: '>=12'}
+
   d3-force@1.2.1:
     resolution: {integrity: sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==}
 
@@ -5540,6 +5561,9 @@ packages:
   d3-interpolate@3.0.1:
     resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
     engines: {node: '>=12'}
+
+  d3-octree@1.1.0:
+    resolution: {integrity: sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==}
 
   d3-path@1.0.9:
     resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
@@ -6416,6 +6440,10 @@ packages:
   flatten-vertex-data@1.0.2:
     resolution: {integrity: sha512-BvCBFK2NZqerFTdMDgqfHBwxYWnxeCkwONsw6PvBMcUXqo8U/KDWwmXhqx1x2kLIg7DqIsJfOaJFOmlua3Lxuw==}
 
+  float-tooltip@1.7.5:
+    resolution: {integrity: sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==}
+    engines: {node: '>=12'}
+
   focus-trap-react@11.0.6:
     resolution: {integrity: sha512-8YbWR8kDf2pQ8G9LT11p39VY4T7eWVrj00Fhp1HUSdv5uW9q6+WK8OMAdy9Ui7vGb1zNouFDzwBIqJwt82rIYQ==}
     peerDependencies:
@@ -6454,6 +6482,10 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  force-graph@1.51.4:
+    resolution: {integrity: sha512-TdJ2KbkoiDQ7NIRx8IPGD0mAXXpLhamS7c+b7W98b0MHG7lphnda1VOQX/98UDTsttIAdH4TcP0l0MauSnLK8w==}
+    engines: {node: '>=12'}
 
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -6915,6 +6947,10 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  index-array-by@1.4.2:
+    resolution: {integrity: sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==}
+    engines: {node: '>=12'}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -7219,6 +7255,10 @@ packages:
     resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
     engines: {node: 20 || >=22}
 
+  jerrypick@1.1.2:
+    resolution: {integrity: sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==}
+    engines: {node: '>=12'}
+
   jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
@@ -7338,6 +7378,10 @@ packages:
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  kapsule@1.16.3:
+    resolution: {integrity: sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==}
+    engines: {node: '>=12'}
 
   katex@0.16.28:
     resolution: {integrity: sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg==}
@@ -8781,6 +8825,12 @@ packages:
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
 
+  react-force-graph-2d@1.29.1:
+    resolution: {integrity: sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '*'
+
   react-instantsearch-core@7.23.2:
     resolution: {integrity: sha512-OHp/iuTeL7VGFXkUPbIZmQEQWxNQn+pE082DKRIo4vIr1QRR70CtD7emuln8CxfQr4Soil7xTgoYuUUoTWG6xw==}
     peerDependencies:
@@ -8802,6 +8852,12 @@ packages:
 
   react-is@19.2.4:
     resolution: {integrity: sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==}
+
+  react-kapsule@2.6.0:
+    resolution: {integrity: sha512-HzLJoYb1n1kfwjXbqFFcRR0EA6oPsJ64tNdDmCSaL/bz2o9wUZRSb0cMe//grLFeF9EVoL4CD/e6ozLyzEv+PQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.13.1'
 
   react-leaflet@5.0.0:
     resolution: {integrity: sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==}
@@ -15179,6 +15235,8 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accessor-fn@1.5.3: {}
+
   acorn-import-phases@1.0.4(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -15560,6 +15618,8 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  bezier-js@6.1.4: {}
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -15682,6 +15742,10 @@ snapshots:
   caniuse-lite@1.0.30001769: {}
 
   caniuse-lite@1.0.30001793: {}
+
+  canvas-color-tracker@1.3.2:
+    dependencies:
+      tinycolor2: 1.6.0
 
   canvas-fit@1.5.0:
     dependencies:
@@ -16067,6 +16131,8 @@ snapshots:
 
   d3-axis@3.0.0: {}
 
+  d3-binarytree@1.0.2: {}
+
   d3-brush@2.1.0:
     dependencies:
       d3-dispatch: 2.0.0
@@ -16151,6 +16217,14 @@ snapshots:
     dependencies:
       d3-dsv: 3.0.1
 
+  d3-force-3d@3.0.6:
+    dependencies:
+      d3-binarytree: 1.0.2
+      d3-dispatch: 3.0.1
+      d3-octree: 1.1.0
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
   d3-force@1.2.1:
     dependencies:
       d3-collection: 1.0.7
@@ -16214,6 +16288,8 @@ snapshots:
   d3-interpolate@3.0.1:
     dependencies:
       d3-color: 3.1.0
+
+  d3-octree@1.1.0: {}
 
   d3-path@1.0.9: {}
 
@@ -17447,6 +17523,12 @@ snapshots:
     dependencies:
       dtype: 2.0.0
 
+  float-tooltip@1.7.5:
+    dependencies:
+      d3-selection: 3.0.0
+      kapsule: 1.16.3
+      preact: 10.28.3
+
   focus-trap-react@11.0.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       '@types/react': 19.2.2
@@ -17475,6 +17557,24 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  force-graph@1.51.4:
+    dependencies:
+      '@tweenjs/tween.js': 23.1.3
+      accessor-fn: 1.5.3
+      bezier-js: 6.1.4
+      canvas-color-tracker: 1.3.2
+      d3-array: 3.2.4
+      d3-drag: 3.0.0
+      d3-force-3d: 3.0.6
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+      float-tooltip: 1.7.5
+      index-array-by: 1.4.2
+      kapsule: 1.16.3
+      lodash-es: 4.18.1
 
   form-data@4.0.5:
     dependencies:
@@ -18137,6 +18237,8 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  index-array-by@1.4.2: {}
+
   inherits@2.0.4: {}
 
   ini@4.1.3: {}
@@ -18435,6 +18537,8 @@ snapshots:
     dependencies:
       '@isaacs/cliui': 9.0.0
 
+  jerrypick@1.1.2: {}
+
   jest-worker@27.5.1:
     dependencies:
       '@types/node': 24.10.13
@@ -18567,6 +18671,10 @@ snapshots:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.2.1
+
+  kapsule@1.16.3:
+    dependencies:
+      lodash-es: 4.18.1
 
   katex@0.16.28:
     dependencies:
@@ -20711,6 +20819,13 @@ snapshots:
     dependencies:
       react: 19.2.1
 
+  react-force-graph-2d@1.29.1(react@19.2.1):
+    dependencies:
+      force-graph: 1.51.4
+      prop-types: 15.8.1
+      react: 19.2.1
+      react-kapsule: 2.6.0(react@19.2.1)
+
   react-instantsearch-core@7.23.2(algoliasearch@5.48.1)(react@19.2.1):
     dependencies:
       '@babel/runtime': 7.28.6
@@ -20737,6 +20852,11 @@ snapshots:
   react-is@17.0.2: {}
 
   react-is@19.2.4: {}
+
+  react-kapsule@2.6.0(react@19.2.1):
+    dependencies:
+      jerrypick: 1.1.2
+      react: 19.2.1
 
   react-leaflet@5.0.0(leaflet@1.9.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:


### PR DESCRIPTION
## Summary

- Adds a force-directed knowledge graph mini panel to every page, showing the current note at centre with all connected notes radiating outward — hover to dim unrelated nodes, click to navigate, expand button opens a full-size modal
- `showKnowledgeGraph` config option (mirrors `showToc`): toggleable in the dashboard under **Settings → Content**, via `config.json`, or per-page in frontmatter; defaults to `true`
- Changelog entry and docs reference page added

## Test Plan

- [ ] Graph panel renders on a page that has links in and out
- [ ] Current note is highlighted (orange) and centred
- [ ] Hovering a node dims unrelated nodes/links with smooth transition
- [ ] Clicking a node navigates to that page
- [ ] Expand button opens full-size modal; clicking outside closes it
- [ ] Graph is hidden when `showKnowledgeGraph: false` set in dashboard
- [ ] Graph is hidden when `showKnowledgeGraph: false` set in `config.json`
- [ ] Graph is hidden when `showKnowledgeGraph: false` set in page frontmatter
- [ ] TOC and graph panel can be toggled independently (right column shows if either is on)
- [ ] Page with no links still renders without error (panel returns null)