### PR TITLE
feat(auth): add email magic-link sign-in

### DIFF
--- a/apps/flowershow/app/(cloud)/login/_components/login-button.tsx
+++ b/apps/flowershow/app/(cloud)/login/_components/login-button.tsx
@@ -6,9 +6,28 @@ import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import LoadingDots from '@/components/icons/loading-dots';
 
+// Basic email shape check — good enough for client-side feedback.
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const isValidEmail = (value: string) => EMAIL_REGEX.test(value.trim());
+
+// Map NextAuth error codes (passed in the URL as ?error=) to friendly messages.
+const ERROR_MESSAGES: Record<string, string> = {
+  Verification:
+    'This sign-in link has expired or has already been used. Please request a new one.',
+  EmailSignin:
+    'We could not send the sign-in email. Please try again in a moment.',
+};
+
 export default function LoginButton() {
   const [githubLoading, setGithubLoading] = useState(false);
   const [googleLoading, setGoogleLoading] = useState(false);
+  const [emailLoading, setEmailLoading] = useState(false);
+  const [email, setEmail] = useState('');
+  const [emailTouched, setEmailTouched] = useState(false);
+  const [linkSent, setLinkSent] = useState(false);
+
+  const emailIsValid = isValidEmail(email);
+  const showEmailError = emailTouched && !emailIsValid;
 
   // Get error message added by next/auth in URL.
   const searchParams = useSearchParams();
@@ -16,13 +35,58 @@ export default function LoginButton() {
   const callbackUrl = searchParams?.get('callbackUrl');
 
   useEffect(() => {
-    const errorMessage = Array.isArray(error) ? error.pop() : error;
-    if (errorMessage) {
-      toast.error(errorMessage);
+    const errorCode = Array.isArray(error) ? error.pop() : error;
+    if (errorCode) {
+      toast.error(ERROR_MESSAGES[errorCode] ?? errorCode);
     }
   }, [error]);
 
-  const isLoading = githubLoading || googleLoading;
+  const isLoading = githubLoading || googleLoading || emailLoading;
+
+  const handleEmailSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setEmailTouched(true);
+    if (!emailIsValid) return;
+
+    setEmailLoading(true);
+    try {
+      const res = await signIn('email', {
+        email,
+        redirect: false,
+        callbackUrl: callbackUrl || '/',
+      });
+
+      if (res?.error) {
+        toast.error(ERROR_MESSAGES[res.error] ?? res.error);
+      } else {
+        setLinkSent(true);
+      }
+    } catch {
+      toast.error('Something went wrong. Please try again.');
+    } finally {
+      setEmailLoading(false);
+    }
+  };
+
+  if (linkSent) {
+    return (
+      <div className="space-y-3 text-center">
+        <h2 className="font-dashboard-heading text-lg">Check your inbox</h2>
+        <p className="text-sm text-stone-600">
+          We&apos;ve sent a sign-in link to{' '}
+          <span className="font-medium">{email}</span>. Click the link in that
+          email to sign in. It may take a minute to arrive.
+        </p>
+        <button
+          type="button"
+          onClick={() => setLinkSent(false)}
+          className="text-sm font-medium underline hover:text-primary-subtle"
+        >
+          Use a different email
+        </button>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-3">
@@ -51,7 +115,7 @@ export default function LoginButton() {
               <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
             </svg>
             <p className="text-sm font-medium text-stone-600 ">
-              Login with GitHub
+              Continue with GitHub
             </p>
           </>
         )}
@@ -92,11 +156,64 @@ export default function LoginButton() {
               />
             </svg>
             <p className="text-sm font-medium text-stone-600 ">
-              Login with Google
+              Continue with Google
             </p>
           </>
         )}
       </button>
+
+      <div className="flex items-center gap-3 py-1">
+        <div className="h-px flex-1 bg-stone-200" />
+        <span className="text-xs uppercase text-stone-400">or</span>
+        <div className="h-px flex-1 bg-stone-200" />
+      </div>
+
+      <form onSubmit={handleEmailSubmit} noValidate className="space-y-3">
+        <div className="space-y-1">
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => {
+              setEmail(e.target.value);
+              setEmailTouched(false);
+            }}
+            disabled={isLoading}
+            placeholder="Enter your email"
+            aria-invalid={showEmailError}
+            className={`h-10 w-full rounded-md border px-3 text-sm text-stone-700 placeholder:text-stone-400 focus:outline-none disabled:cursor-not-allowed disabled:bg-stone-50 ${
+              showEmailError
+                ? 'border-red-400 focus:border-red-500'
+                : 'border-stone-200 focus:border-stone-400'
+            }`}
+          />
+          {showEmailError && (
+            <p className="text-xs text-red-500">
+              Please enter a valid email address.
+            </p>
+          )}
+        </div>
+        <button
+          type="submit"
+          disabled={isLoading || !email.trim()}
+          className={`${
+            isLoading || !email.trim()
+              ? 'cursor-not-allowed bg-stone-200 '
+              : 'bg-black hover:bg-stone-800 active:bg-stone-700   '
+          } group flex h-10 w-full items-center justify-center space-x-2 rounded-md border border-transparent transition-colors duration-75 focus:outline-none `}
+        >
+          {emailLoading ? (
+            <LoadingDots color="#A8A29E" />
+          ) : (
+            <p
+              className={`text-sm font-medium ${
+                email.trim() ? 'text-white' : 'text-stone-400'
+              }`}
+            >
+              Continue
+            </p>
+          )}
+        </button>
+      </form>
     </div>
   );
 }

--- a/apps/flowershow/emails/magic-link.tsx
+++ b/apps/flowershow/emails/magic-link.tsx
@@ -1,0 +1,49 @@
+import { Button, Markdown } from '@react-email/components';
+import { EmailLayout } from './components/email-layout';
+
+interface MagicLinkEmailProps {
+  url: string;
+}
+
+export function MagicLinkEmail({
+  url = 'https://flowershow.app',
+}: MagicLinkEmailProps) {
+  return (
+    <EmailLayout previewText="Your Flowershow sign-in link">
+      <Markdown
+        markdownCustomStyles={{
+          h1: {
+            fontSize: '24px',
+            fontWeight: 'bold',
+            color: '#1a1a1a',
+            margin: '0 0 16px',
+          },
+          p: { fontSize: '16px', lineHeight: '26px', color: '#484848' },
+          link: { color: '#000000', textDecoration: 'underline' },
+        }}
+      >
+        {`# Sign in to Flowershow
+
+Click the button below to sign in. This link will expire in 24 hours and can only be used once.`}
+      </Markdown>
+      <Button
+        className="bg-black rounded-md text-white text-base text-center block py-3 px-6 my-6"
+        href={url}
+      >
+        Sign in to Flowershow
+      </Button>
+      <Markdown
+        markdownCustomStyles={{
+          p: { fontSize: '14px', lineHeight: '24px', color: '#8898aa' },
+          link: { color: '#000000', textDecoration: 'underline' },
+        }}
+      >
+        {`If you didn't request this email, you can safely ignore it.
+
+— The Flowershow team`}
+      </Markdown>
+    </EmailLayout>
+  );
+}
+
+export default MagicLinkEmail;

--- a/apps/flowershow/lib/generate-username.test.ts
+++ b/apps/flowershow/lib/generate-username.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { slugifyUsername } from './generate-username';
+
+describe('slugifyUsername', () => {
+  it('lowercases the local part', () => {
+    expect(slugifyUsername('JohnDoe@example.com')).toBe('johndoe');
+  });
+
+  it('strips dots, plus and underscores', () => {
+    expect(slugifyUsername('john.doe@example.com')).toBe('johndoe');
+    expect(slugifyUsername('john+tag@example.com')).toBe('johntag');
+    expect(slugifyUsername('john_doe@example.com')).toBe('johndoe');
+  });
+
+  it('strips every other non-alphanumeric character', () => {
+    expect(slugifyUsername('john  doe@example.com')).toBe('johndoe');
+    expect(slugifyUsername('john!!doe@example.com')).toBe('johndoe');
+    expect(slugifyUsername('!john!@example.com')).toBe('john');
+  });
+
+  it('transliterates accented Latin characters to ASCII', () => {
+    expect(slugifyUsername('józef@example.com')).toBe('jozef');
+    expect(slugifyUsername('André@example.com')).toBe('andre');
+    expect(slugifyUsername('müller@example.com')).toBe('muller');
+    expect(slugifyUsername('joão@example.com')).toBe('joao');
+  });
+
+  it('falls back to "user" when nothing usable remains', () => {
+    expect(slugifyUsername('...@example.com')).toBe('user');
+    expect(slugifyUsername('@example.com')).toBe('user');
+  });
+
+  it('keeps digits', () => {
+    expect(slugifyUsername('user123@example.com')).toBe('user123');
+  });
+});

--- a/apps/flowershow/lib/generate-username.ts
+++ b/apps/flowershow/lib/generate-username.ts
@@ -1,0 +1,50 @@
+import prisma from '@/server/db';
+
+/**
+ * Turn an email address into a subdomain-safe username slug.
+ *
+ * Usernames are used in default site subdomains
+ * (`<sitename>-<username>.flowershow.me`), so the result must only contain
+ * lowercase letters and digits. We transliterate accented Latin characters to
+ * ASCII (`józef` → `jozef`), lowercase, and strip every remaining character
+ * that isn't a letter or digit (so `john.doe`, `john+tag` and `john doe` all
+ * collapse to a single token). Falls back to `user` when nothing usable is
+ * left. The collision suffix in `generateUsername` is the only source of
+ * hyphens in a generated username.
+ */
+export function slugifyUsername(email: string): string {
+  const local = email.split('@')[0] ?? '';
+  const slug = local
+    .normalize('NFKD') // decompose accents: é → e + combining mark
+    .replace(/[\u0300-\u036f]/g, '') // strip the combining marks
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, ''); // strip everything that isn't a letter or digit
+  return slug || 'user';
+}
+
+/**
+ * Produce a unique, subdomain-safe username derived from an email address.
+ *
+ * Starts from the sanitised slug and appends an incrementing numeric suffix
+ * (`slug-2`, `slug-3`, …) until an unused username is found. Used for sign-in
+ * methods that have no OAuth profile to derive a username from (magic link),
+ * and for Google sign-ups (whose raw email prefix was neither sanitised nor
+ * collision-checked).
+ */
+export async function generateUsername(email: string): Promise<string> {
+  const base = slugifyUsername(email);
+  let candidate = base;
+  let suffix = 1;
+
+  while (
+    await prisma.user.findUnique({
+      where: { username: candidate },
+      select: { id: true },
+    })
+  ) {
+    suffix += 1;
+    candidate = `${base}-${suffix}`;
+  }
+
+  return candidate;
+}

--- a/apps/flowershow/package.json
+++ b/apps/flowershow/package.json
@@ -80,6 +80,7 @@
     "next": "15.5.18",
     "next-auth": "4.24.12",
     "next-mdx-remote-client": "^2.1.7",
+    "nodemailer": "^7.0.13",
     "papaparse": "^5.5.3",
     "postcss-prefixwrap": "^1.57.0",
     "posthog-js": "^1.279.3",

--- a/apps/flowershow/server/auth.ts
+++ b/apps/flowershow/server/auth.ts
@@ -1,15 +1,38 @@
 import { PrismaAdapter } from '@next-auth/prisma-adapter';
 import axios from 'axios';
 import { getServerSession, type NextAuthOptions } from 'next-auth';
+import type { Adapter } from 'next-auth/adapters';
+import EmailProvider from 'next-auth/providers/email';
 import GitHubProvider, { GithubProfile } from 'next-auth/providers/github';
 import GoogleProvider from 'next-auth/providers/google';
 import { env } from '@/env.mjs';
+import { MagicLinkEmail } from '@/emails/magic-link';
 import { WelcomeEmail } from '@/emails/welcome';
 import { sendEmail } from '@/lib/email';
+import { generateUsername } from '@/lib/generate-username';
 import PostHogClient from '@/lib/server-posthog';
 import prisma from '@/server/db';
 
 const VERCEL_DEPLOYMENT = !!env.VERCEL_URL;
+
+// Per-email cooldown between magic-link emails, to prevent inbox spamming and
+// protect sender deliverability.
+const MAGIC_LINK_COOLDOWN_MS = 60 * 1000;
+
+// Wrap the Prisma adapter so that `username` (required, unique, subdomain-safe)
+// is always set when creating a user. OAuth sign-ins pass a username through
+// their `profile()` callback (GitHub uses the login as-is); magic-link and
+// Google sign-ins have it generated from the email address.
+const prismaAdapter = PrismaAdapter(prisma);
+const adapter: Adapter = {
+  ...prismaAdapter,
+  createUser: async (data) => {
+    const username =
+      (data as { username?: string }).username ??
+      (await generateUsername(data.email!));
+    return prismaAdapter.createUser!({ ...data, username } as typeof data);
+  },
+};
 
 export const authOptions: NextAuthOptions = {
   providers: [
@@ -40,18 +63,43 @@ export const authOptions: NextAuthOptions = {
     GoogleProvider({
       clientId: env.AUTH_GOOGLE_ID as string,
       clientSecret: env.AUTH_GOOGLE_SECRET as string,
-      profile(profile) {
-        const username =
-          profile.email?.split('@')[0] ||
-          profile.name?.replace(/\s+/g, '-').toLowerCase() ||
-          profile.sub;
+      async profile(profile) {
         return {
           id: profile.sub,
           name: profile.name,
           email: profile.email,
           image: profile.picture,
-          username: username,
+          // Generated (sanitised + collision-checked) from the email rather
+          // than using the raw email prefix.
+          username: await generateUsername(profile.email),
         };
+      },
+    }),
+    EmailProvider({
+      from: 'Flowershow <support@flowershow.app>',
+      sendVerificationRequest: async ({ identifier: email, url, expires }) => {
+        const recentToken = await prisma.verificationToken.findFirst({
+          where: {
+            identifier: email,
+            expires: {
+              gt: new Date(expires.getTime() - MAGIC_LINK_COOLDOWN_MS),
+              lt: expires,
+            },
+          },
+        });
+
+        if (recentToken) {
+          // A link was just sent; silently skip to avoid inbox spam. The user
+          // already received (or is about to receive) the first email.
+          console.log(`Magic-link cooldown active for ${email}, skipping send`);
+          return;
+        }
+
+        await sendEmail({
+          to: email,
+          subject: 'Your Flowershow sign-in link',
+          react: MagicLinkEmail({ url }),
+        });
       },
     }),
   ],
@@ -60,7 +108,7 @@ export const authOptions: NextAuthOptions = {
     verifyRequest: `/login`,
     error: '/login', // Error code passed in query string as ?error=
   },
-  adapter: PrismaAdapter(prisma),
+  adapter,
   session: {
     strategy: 'jwt',
     maxAge: 30 * 24 * 60 * 60, // 30 days
@@ -109,11 +157,22 @@ export const authOptions: NextAuthOptions = {
         }
       }
 
-      // Look up the OAuth account that was just created to determine the auth provider
-      const account = await prisma.account.findFirst({
-        where: { userId: user.id },
-        select: { provider: true },
+      // Send welcome email
+      const userName = user.name?.split(' ')[0] || 'there';
+      await sendEmail({
+        to: user.email!,
+        subject: 'Welcome to Flowershow',
+        react: WelcomeEmail({ userName }),
       });
+    },
+    signIn: async ({ user, account, isNewUser }) => {
+      // Capture sign_up here rather than in `createUser`: for OAuth,
+      // `events.createUser` fires before `linkAccount`, so no Account row
+      // exists yet to read the provider from; for magic-link there is never an
+      // Account row at all. This event runs after linking and receives the
+      // `account` directly, so `account.provider` is reliable for every flow
+      // ('github' | 'google' | 'email').
+      if (!isNewUser) return;
 
       const posthog = PostHogClient();
       posthog.capture({
@@ -124,14 +183,6 @@ export const authOptions: NextAuthOptions = {
         },
       });
       await posthog.shutdown();
-
-      // Send welcome email
-      const userName = user.name?.split(' ')[0] || 'there';
-      await sendEmail({
-        to: user.email!,
-        subject: 'Welcome to Flowershow',
-        react: WelcomeEmail({ userName }),
-      });
     },
   },
   callbacks: {
@@ -178,6 +229,11 @@ export const authOptions: NextAuthOptions = {
       //   on subsequent sign in - prisma user
       // account: OAuth response with fresh tokens from provider
       // profile: full GitHub or Google profile
+      // Magic-link sign-ins have no OAuth profile — the token was already
+      // verified by NextAuth before this callback runs, so allow them through
+      // before the OAuth-only account/token logic below.
+      if (account?.provider === 'email') return true;
+
       if (!account || !profile) return false;
 
       const existingAccount = await prisma.account.findFirst({

--- a/content/flowershow-app/changelog/2026-07-08-email-sign-in.md
+++ b/content/flowershow-app/changelog/2026-07-08-email-sign-in.md
@@ -1,0 +1,12 @@
+---
+title: "Sign in with email"
+date: 2026-07-08
+description: You can now sign in to Flowershow with a magic link sent to your email — no GitHub or Google account required.
+authors:
+  - olayway
+showToc: false
+---
+
+You can now sign in to Flowershow using just your email address. Enter your email on the login page and we'll send you a magic link — click it and you're in. No password to remember, and no GitHub or Google account required.
+
+Signing in with GitHub or Google still works exactly as before.

--- a/content/flowershow-app/changelog/2026-07-08-email-sign-in.md
+++ b/content/flowershow-app/changelog/2026-07-08-email-sign-in.md
@@ -9,4 +9,4 @@ showToc: false
 
 You can now sign in to Flowershow using just your email address. Enter your email on the login page and we'll send you a magic link — click it and you're in. No password to remember, and no GitHub or Google account required.
 
-Signing in with GitHub or Google still works exactly as before.
+Signing in with GitHub or Google still works exactly as before. And if you originally signed up with Google or GitHub, a magic link sent to that same email address signs you into your existing account — it won't create a duplicate.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,7 +135,7 @@ importers:
         version: 8.27.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.1))(@types/react@19.2.2)(react@19.2.1))(@mui/material@7.3.8(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.1))(@types/react@19.2.2)(react@19.2.1))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@mui/system@7.3.8(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.1))(@types/react@19.2.2)(react@19.2.1))(@types/react@19.2.2)(react@19.2.1))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@5.5.2(prisma@5.5.2))(next-auth@4.24.12(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+        version: 1.0.7(@prisma/client@5.5.2(prisma@5.5.2))(next-auth@4.24.12(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(nodemailer@7.0.13)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@next/third-parties':
         specifier: 15.5.6
         version: 15.5.6(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
@@ -264,10 +264,13 @@ importers:
         version: 15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       next-auth:
         specifier: 4.24.12
-        version: 4.24.12(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 4.24.12(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(nodemailer@7.0.13)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       next-mdx-remote-client:
         specifier: ^2.1.7
         version: 2.1.7(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(unified@11.0.5)
+      nodemailer:
+        specifier: ^7.0.13
+        version: 7.0.13
       papaparse:
         specifier: ^5.5.3
         version: 5.5.3
@@ -8231,6 +8234,10 @@ packages:
     resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
     engines: {node: '>=18'}
 
+  nodemailer@7.0.13:
+    resolution: {integrity: sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==}
+    engines: {node: '>=6.0.0'}
+
   nopt@1.0.10:
     resolution: {integrity: sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==}
     hasBin: true
@@ -12804,10 +12811,10 @@ snapshots:
 
   '@neoconfetti/react@1.0.0': {}
 
-  '@next-auth/prisma-adapter@1.0.7(@prisma/client@5.5.2(prisma@5.5.2))(next-auth@4.24.12(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
+  '@next-auth/prisma-adapter@1.0.7(@prisma/client@5.5.2(prisma@5.5.2))(next-auth@4.24.12(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(nodemailer@7.0.13)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
     dependencies:
       '@prisma/client': 5.5.2(prisma@5.5.2)
-      next-auth: 4.24.12(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      next-auth: 4.24.12(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(nodemailer@7.0.13)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
 
   '@next/env@15.5.18': {}
 
@@ -15256,14 +15263,13 @@ snapshots:
 
   acorn-walk@8.3.4:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
 
   acorn@7.4.1: {}
 
   acorn@8.15.0: {}
 
-  acorn@8.16.0:
-    optional: true
+  acorn@8.16.0: {}
 
   ag-charts-types@12.3.1: {}
 
@@ -19972,7 +19978,7 @@ snapshots:
   netmask@2.0.2:
     optional: true
 
-  next-auth@4.24.12(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+  next-auth@4.24.12(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(nodemailer@7.0.13)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       '@babel/runtime': 7.28.6
       '@panva/hkdf': 1.2.1
@@ -19986,6 +19992,8 @@ snapshots:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
       uuid: 8.3.2
+    optionalDependencies:
+      nodemailer: 7.0.13
 
   next-mdx-remote-client@2.1.7(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(unified@11.0.5):
     dependencies:
@@ -20072,6 +20080,8 @@ snapshots:
 
   node-releases@2.0.46:
     optional: true
+
+  nodemailer@7.0.13: {}
 
   nopt@1.0.10:
     dependencies:
@@ -22262,7 +22272,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 24.10.13
-      acorn: 8.15.0
+      acorn: 8.16.0
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1


### PR DESCRIPTION
## Summary

Adds passwordless email (magic-link) sign-in alongside the existing GitHub/Google OAuth options.

Closes #1299

## Changes

- **EmailProvider** (Resend via `sendEmail`) with a React-Email magic-link template (`emails/magic-link.tsx`) and a ~60s per-email cooldown to prevent spamming.
- **Username generation** on account creation (`lib/generate-username.ts`): slugifies the email local-part with NFKD transliteration of accented Latin (e.g. `józef` → `jozef`) and appends a DB-backed collision suffix (`slug-2`). Unit tests in `lib/generate-username.test.ts`.
- **Login form** (`login-button.tsx`): new email field with client-side validation — the "Please enter a valid email address." error shows only after clicking Continue and clears on edit. Continue button is black when enabled and grey/disabled when the field is empty. Inline "Check your inbox" confirmation state after sending.
- **Analytics fix**: `sign_up` now captures `auth_provider` in `events.signIn` (gated on `isNewUser`) instead of `events.createUser`. The old location fired before the OAuth Account link existed, so every historical `sign_up` reported `unknown` — this fixes both the new email flow and the pre-existing OAuth bug.

## Testing

- `npx tsc --noEmit` — clean
- Unit tests: `cd apps/flowershow && npx vitest run --project=unit generate-username`

## Notes

There is a known edge case (documented during implementation, not a code bug): magic-link tokens are single-use, so link prefetchers/scanners (e.g. Outlook SafeLinks) can consume the token before the user clicks, producing an "expired or already used" error. A robust fix (a confirm-sign-in interstitial) is likely a follow-up, out of scope for #1299.