### PR TITLE
feat(email): transactional emails for billing lifecycle

### DIFF
--- a/apps/flowershow/__tests__/lib/email.test.ts
+++ b/apps/flowershow/__tests__/lib/email.test.ts
@@ -32,7 +32,24 @@ describe('email client', () => {
         to: 'test@example.com',
         subject: 'Test Subject',
       }),
+      undefined,
     );
     expect(result.data?.id).toBe('test-id');
+  });
+
+  it('forwards an idempotencyKey to resend when provided', async () => {
+    const { sendEmail, resend } = await import('@/lib/email');
+    const React = await import('react');
+
+    await sendEmail({
+      to: 'test@example.com',
+      subject: 'Test Subject',
+      react: React.createElement('div', null, 'Hello'),
+      idempotencyKey: 'expiry:sub_1',
+    });
+
+    expect(resend.emails.send).toHaveBeenCalledWith(expect.any(Object), {
+      idempotencyKey: 'expiry:sub_1',
+    });
   });
 });

--- a/apps/flowershow/app/api/stripe/webhook/route.test.ts
+++ b/apps/flowershow/app/api/stripe/webhook/route.test.ts
@@ -1,0 +1,266 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mocks must be declared before the imports they affect (vi.mock is hoisted).
+
+vi.mock('next/headers', () => ({
+  headers: () => ({ get: () => 'test-signature' }),
+}));
+
+vi.mock('@/lib/stripe', () => ({
+  stripe: {
+    webhooks: { constructEvent: vi.fn() },
+    subscriptions: { retrieve: vi.fn() },
+  },
+}));
+
+vi.mock('@/server/db', () => ({
+  default: {
+    subscription: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      create: vi.fn(),
+      delete: vi.fn(),
+    },
+    site: { update: vi.fn() },
+    user: { findUnique: vi.fn(), update: vi.fn() },
+  },
+}));
+
+vi.mock('@/lib/email', () => ({
+  sendEmail: vi
+    .fn()
+    .mockResolvedValue({ data: { id: 'email-1' }, error: null }),
+}));
+
+vi.mock('@/lib/domains', () => ({
+  removeDomainAndVariantFromVercelProject: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/server-posthog', () => ({
+  default: () => ({
+    capture: vi.fn(),
+    captureException: vi.fn(),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@/lib/otel-logger', () => ({
+  log: vi.fn(),
+  SeverityNumber: { ERROR: 17 },
+}));
+
+import { sendEmail } from '@/lib/email';
+import { stripe } from '@/lib/stripe';
+import prisma from '@/server/db';
+import { POST } from './route';
+
+const USER = {
+  id: 'user-1',
+  email: 'ada@example.com',
+  name: 'Ada Lovelace',
+  cancelBonusGrantedAt: null as Date | null,
+};
+
+function makeDbSubscription(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'dbsub-1',
+    siteId: 'site-1',
+    interval: 'month',
+    currentPeriodEnd: new Date('2026-08-01T00:00:00Z'),
+    cancelAtPeriodEnd: false,
+    site: {
+      id: 'site-1',
+      projectName: 'My Blog',
+      userId: USER.id,
+      customDomain: null,
+      privacyMode: 'PUBLIC',
+      user: { ...USER },
+    },
+    ...overrides,
+  };
+}
+
+// Serialize the react body of the most recent sendEmail call so we can assert
+// on its text content (e.g. that it names the specific site). We inspect the
+// element tree rather than rendering it — react-email's layout suspends under
+// renderToStaticMarkup, and the site name is a plain string child regardless.
+function lastEmailText() {
+  const call = vi.mocked(sendEmail).mock.lastCall;
+  return JSON.stringify((call![0] as any).react);
+}
+
+function fireEvent(event: any) {
+  vi.mocked(stripe.webhooks.constructEvent).mockReturnValue(event);
+  const req = new Request('http://localhost/api/stripe/webhook', {
+    method: 'POST',
+    body: 'raw-body',
+  });
+  return POST(req);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(prisma.subscription.update).mockResolvedValue({} as any);
+  vi.mocked(prisma.site.update).mockResolvedValue({} as any);
+  vi.mocked(prisma.user.update).mockResolvedValue({} as any);
+  vi.mocked(prisma.user.findUnique).mockResolvedValue({ ...USER } as any);
+});
+
+describe('stripe webhook — cancellation split', () => {
+  function subscriptionEvent(sub: Record<string, unknown>) {
+    return {
+      type: 'customer.subscription.updated',
+      data: {
+        object: {
+          id: 'sub_1',
+          status: 'active',
+          cancel_at_period_end: false,
+          current_period_start: 1893369600,
+          current_period_end: 1893456000,
+          items: {
+            data: [
+              { price: { id: 'price_1', recurring: { interval: 'month' } } },
+            ],
+          },
+          ...sub,
+        },
+      },
+    };
+  }
+
+  it('voluntary cancellation sends the downgrade email, not the expiry email', async () => {
+    vi.mocked(prisma.subscription.findUnique).mockResolvedValue(
+      makeDbSubscription({ cancelAtPeriodEnd: false }) as any,
+    );
+
+    await fireEvent(
+      subscriptionEvent({ status: 'active', cancel_at_period_end: true }),
+    );
+
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: 'Your Flowershow subscription has been cancelled',
+      }),
+    );
+  });
+
+  it('involuntary (payment_failure) expiry sends the expired email, not the downgrade email', async () => {
+    vi.mocked(prisma.subscription.findUnique).mockResolvedValue(
+      makeDbSubscription({ cancelAtPeriodEnd: false }) as any,
+    );
+
+    const res = await fireEvent(
+      subscriptionEvent({
+        status: 'canceled',
+        cancel_at_period_end: false,
+        cancellation_details: { reason: 'payment_failure' },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: 'Your Flowershow Premium has expired',
+      }),
+    );
+    // The email names the specific site the subscription belonged to.
+    expect(lastEmailText()).toContain('My Blog');
+    // Site is reverted to FREE.
+    expect(prisma.site.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ plan: 'FREE' }),
+      }),
+    );
+  });
+
+  it('voluntary immediate cancellation does NOT send the involuntary expiry email', async () => {
+    vi.mocked(prisma.subscription.findUnique).mockResolvedValue(
+      makeDbSubscription({ cancelAtPeriodEnd: false }) as any,
+    );
+
+    await fireEvent(
+      subscriptionEvent({
+        status: 'canceled',
+        cancel_at_period_end: false,
+        cancellation_details: { reason: 'cancellation_requested' },
+      }),
+    );
+
+    const subjects = vi
+      .mocked(sendEmail)
+      .mock.calls.map((c) => (c[0] as any).subject);
+    expect(subjects).not.toContain('Your Flowershow Premium has expired');
+  });
+
+  it('passes a stable idempotency key so Resend dedupes redelivered expiry events', async () => {
+    vi.mocked(prisma.subscription.findUnique).mockResolvedValue(
+      makeDbSubscription({ cancelAtPeriodEnd: false }) as any,
+    );
+
+    await fireEvent(
+      subscriptionEvent({
+        status: 'canceled',
+        cancel_at_period_end: false,
+        cancellation_details: { reason: 'payment_failure' },
+      }),
+    );
+
+    // Dedup is delegated to Resend via a stable key keyed on the subscription;
+    // a redelivered event reuses the key and Resend suppresses the second send.
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: 'Your Flowershow Premium has expired',
+        idempotencyKey: 'expiry:sub_1',
+      }),
+    );
+  });
+});
+
+describe('stripe webhook — annual renewal reminder (invoice.upcoming)', () => {
+  function upcomingEvent(interval: string) {
+    return {
+      type: 'invoice.upcoming',
+      data: {
+        object: {
+          subscription: 'sub_1',
+          amount_due: 5000,
+          currency: 'usd',
+          period_end: 1893456000,
+          lines: { data: [{ price: { recurring: { interval } } }] },
+        },
+      },
+    };
+  }
+
+  it('sends a reminder for a yearly plan', async () => {
+    vi.mocked(prisma.subscription.findUnique).mockResolvedValue(
+      makeDbSubscription({ interval: 'year' }) as any,
+    );
+
+    const res = await fireEvent(upcomingEvent('year'));
+
+    expect(res.status).toBe(200);
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: USER.email,
+        subject: 'Your Flowershow Premium renews soon',
+      }),
+    );
+    // The reminder names the specific site being renewed.
+    expect(lastEmailText()).toContain('My Blog');
+  });
+
+  it('sends nothing for a monthly plan', async () => {
+    vi.mocked(prisma.subscription.findUnique).mockResolvedValue(
+      makeDbSubscription({ interval: 'month' }) as any,
+    );
+
+    const res = await fireEvent(upcomingEvent('month'));
+
+    expect(res.status).toBe(200);
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+});

--- a/apps/flowershow/app/api/stripe/webhook/route.ts
+++ b/apps/flowershow/app/api/stripe/webhook/route.ts
@@ -3,18 +3,45 @@ import { headers } from 'next/headers';
 import { NextResponse } from 'next/server';
 import { env } from '@/env.mjs';
 import { PremiumDowngradeEmail } from '@/emails/premium-downgrade';
+import { PremiumExpiredEmail } from '@/emails/premium-expired';
 import { PremiumUpgradeEmail } from '@/emails/premium-upgrade';
+import { RenewalReminderEmail } from '@/emails/renewal-reminder';
 import { removeDomainAndVariantFromVercelProject } from '@/lib/domains';
 import { sendEmail } from '@/lib/email';
 import PostHogClient from '@/lib/server-posthog';
 import { stripe } from '@/lib/stripe';
+import { sendTransactionalEmail } from '@/lib/transactional-email';
 import prisma from '@/server/db';
 
+// Email ownership: payment-failure emails are sent by Stripe itself.
+// We therefore do NOT handle `invoice.payment_failed` here.
+// Flowershow only sends emails Stripe does not: annual renewal reminders
+// (invoice.upcoming) and involuntary-expiry notices (subscription cancelled on
+// payment_failure, handled in the subscription case below).
 const relevantEvents = new Set([
   'checkout.session.completed',
   'customer.subscription.updated',
   'customer.subscription.deleted',
+  'invoice.upcoming',
 ]);
+
+const billingSettingsUrl = (siteId: string) =>
+  `https://${env.NEXT_PUBLIC_CLOUD_DOMAIN}/site/${siteId}/settings`;
+
+function formatAmount(
+  amountInCents: number | null | undefined,
+  currency = 'usd',
+) {
+  const value = (amountInCents ?? 0) / 100;
+  try {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: (currency || 'usd').toUpperCase(),
+    }).format(value);
+  } catch {
+    return `$${value.toFixed(2)}`;
+  }
+}
 
 export async function POST(req: Request) {
   const body = await req.text();
@@ -23,15 +50,12 @@ export async function POST(req: Request) {
   let event;
 
   try {
-    console.log(`📥 Incoming Stripe webhook request`);
     event = stripe.webhooks.constructEvent(
       body,
       sig!,
       env.STRIPE_WEBHOOK_SECRET,
     );
-    console.log(`✅ Webhook verified. Event type: ${event.type}`);
   } catch (err: any) {
-    console.error(`❌ Webhook verification failed: ${err.message}`);
     const posthog = PostHogClient();
     posthog.captureException(err, 'system', {
       route: 'POST /api/stripe/webhook',
@@ -48,7 +72,6 @@ export async function POST(req: Request) {
     try {
       switch (event.type) {
         case 'checkout.session.completed': {
-          console.log(`🔄 Processing checkout.session.completed`);
           const checkoutSession = event.data.object as any;
           const subscription = await stripe.subscriptions.retrieve(
             checkoutSession.subscription,
@@ -62,13 +85,6 @@ export async function POST(req: Request) {
             throw new Error('Missing required subscription data');
           }
 
-          console.log(`📋 Subscription details:
-            - Customer: ${checkoutSession.customer}
-            - Site ID: ${checkoutSession.metadata.siteId}
-            - Price ID: ${priceId}
-            - Interval: ${interval}
-          `);
-
           // Check for existing subscription
           const existingSubscription = await prisma.subscription.findUnique({
             where: { siteId: checkoutSession.metadata.siteId },
@@ -79,17 +95,12 @@ export async function POST(req: Request) {
             existingSubscription &&
             existingSubscription.status === 'canceled'
           ) {
-            console.log(
-              `🗑️ Deleting existing canceled subscription: ${existingSubscription.id}`,
-            );
             await prisma.subscription.delete({
               where: { id: existingSubscription.id },
             });
           }
 
           // Create new subscription
-          console.log(`📝 Creating new subscription record`);
-
           await prisma.subscription.create({
             data: {
               siteId: checkoutSession.metadata.siteId,
@@ -109,7 +120,6 @@ export async function POST(req: Request) {
           });
 
           // Update site's features to PREMIUM
-          console.log(`⭐ Upgrading site to PREMIUM plan`);
           const updatedSite = await prisma.site.update({
             where: {
               id: checkoutSession.metadata.siteId,
@@ -147,19 +157,11 @@ export async function POST(req: Request) {
             }),
           });
 
-          console.log(`✅ Checkout session processing completed`);
           break;
         }
         case 'customer.subscription.updated':
         case 'customer.subscription.deleted': {
-          console.log(`🔄 Processing ${event.type}`);
           const subscription = event.data.object as any;
-
-          console.log(`📋 Subscription details:
-            - ID: ${subscription.id}
-            - Status: ${subscription.status}
-          `);
-
           const dbSubscription = await prisma.subscription.findUnique({
             where: {
               stripeSubscriptionId: subscription.id,
@@ -186,8 +188,6 @@ export async function POST(req: Request) {
             subscription.cancel_at_period_end === true &&
             dbSubscription.cancelAtPeriodEnd === false;
 
-          console.log({ justCancelled });
-
           // Look up the user to check if they've already received the cancel bonus
           const user = await prisma.user.findUnique({
             where: { id: dbSubscription.site.userId },
@@ -204,9 +204,6 @@ export async function POST(req: Request) {
           if (grantBonus) {
             periodEnd = new Date(subscription.current_period_end * 1000);
             periodEnd.setMonth(periodEnd.getMonth() + 3);
-            console.log(
-              `⏳ Granting cancel bonus. Extending access until ${periodEnd.toISOString()}`,
-            );
           } else if (
             subscription.cancel_at_period_end === true &&
             dbSubscription.cancelAtPeriodEnd === true
@@ -218,7 +215,6 @@ export async function POST(req: Request) {
             periodEnd = new Date(subscription.current_period_end * 1000);
           }
 
-          console.log(`📝 Updating subscription record`);
           await prisma.subscription.update({
             where: {
               stripeSubscriptionId: subscription.id,
@@ -236,8 +232,6 @@ export async function POST(req: Request) {
           });
 
           if (justCancelled) {
-            console.log(`📧 Subscription cancelled — sending downgrade email`);
-
             if (grantBonus) {
               await prisma.user.update({
                 where: { id: dbSubscription.site.userId },
@@ -281,16 +275,12 @@ export async function POST(req: Request) {
 
           // When Stripe confirms the subscription is fully cancelled, downgrade to FREE
           if (subscription.status === 'canceled') {
-            console.log(`⬇️ Downgrading site to FREE plan`);
             const site = dbSubscription.site;
 
             if (
               site.customDomain &&
               env.NEXT_PUBLIC_VERCEL_ENV === 'production'
             ) {
-              console.log(
-                `🌐 Removing custom domain ${site.customDomain} from Vercel`,
-              );
               await removeDomainAndVariantFromVercelProject(site.customDomain);
             }
 
@@ -307,9 +297,88 @@ export async function POST(req: Request) {
                 }),
               },
             });
+
+            // Involuntary expiry: the subscription was cancelled because payment
+            // failed (not a voluntary cancellation). Send a distinct "expired,
+            // reactivate anytime" email.
+            const cancellationReason =
+              subscription.cancellation_details?.reason;
+            if (cancellationReason === 'payment_failure' && user?.email) {
+              const expiredUserName = user.name?.split(' ')[0] || 'there';
+              await sendTransactionalEmail({
+                to: user.email,
+                subject: 'Your Flowershow Premium has expired',
+                react: PremiumExpiredEmail({
+                  userName: expiredUserName,
+                  siteName: dbSubscription.site.projectName,
+                  reactivateUrl: billingSettingsUrl(dbSubscription.siteId),
+                }),
+                type: 'premium_expired',
+                userId: user.id,
+                idempotencyKey: `expiry:${subscription.id}`,
+                distinctId: user.id,
+                properties: { siteId: dbSubscription.siteId },
+              });
+            }
           }
 
-          console.log(`✅ Subscription update processing completed`);
+          break;
+        }
+        case 'invoice.upcoming': {
+          const invoice = event.data.object as any;
+          const stripeSubscriptionId = invoice.subscription;
+
+          if (!stripeSubscriptionId) {
+            break;
+          }
+
+          const dbSubscription = await prisma.subscription.findUnique({
+            where: { stripeSubscriptionId },
+            include: { site: { include: { user: true } } },
+          });
+
+          const user = dbSubscription?.site.user;
+          if (!dbSubscription || !user?.email) {
+            break;
+          }
+
+          // Annual plans only — monthly renewals send nothing.
+          const lineInterval =
+            invoice.lines?.data?.[0]?.price?.recurring?.interval;
+          const interval = lineInterval ?? dbSubscription.interval;
+          if (interval !== 'year') {
+            break;
+          }
+
+          const periodEnd: number | null =
+            invoice.period_end ?? invoice.next_payment_attempt ?? null;
+          const renewalDate = periodEnd
+            ? new Date(periodEnd * 1000).toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+              })
+            : 'soon';
+          const amount = formatAmount(invoice.amount_due, invoice.currency);
+
+          const renewalUserName = user.name?.split(' ')[0] || 'there';
+          await sendTransactionalEmail({
+            to: user.email,
+            subject: 'Your Flowershow Premium renews soon',
+            react: RenewalReminderEmail({
+              userName: renewalUserName,
+              siteName: dbSubscription.site.projectName,
+              renewalDate,
+              amount,
+              manageBillingUrl: billingSettingsUrl(dbSubscription.siteId),
+            }),
+            type: 'renewal_reminder',
+            userId: user.id,
+            idempotencyKey: `renewal:${stripeSubscriptionId}:${periodEnd}`,
+            distinctId: user.id,
+            properties: { siteId: dbSubscription.siteId, interval: 'year' },
+          });
+
           break;
         }
         default:
@@ -328,11 +397,8 @@ export async function POST(req: Request) {
         { status: 500 },
       );
     }
-  } else {
-    console.log(`ℹ️ Ignoring irrelevant event type: ${event.type}`);
   }
 
-  console.log(`✅ Webhook processing completed successfully`);
   return NextResponse.json({
     received: true,
   } satisfies StripeWebhookReceivedResponse);

--- a/apps/flowershow/components/dashboard/form/delete-account-form.tsx
+++ b/apps/flowershow/components/dashboard/form/delete-account-form.tsx
@@ -1,12 +1,16 @@
 'use client';
 
 import { signOut } from 'next-auth/react';
+import { useState } from 'react';
 import { toast } from 'sonner';
 import LoadingDots from '@/components/icons/loading-dots';
 import clsx from 'clsx';
 import { api } from '@/trpc/react';
 
 export default function DeleteAccountForm({ username }: { username: string }) {
+  const [confirmValue, setConfirmValue] = useState('');
+  const confirmationMatches = confirmValue === username;
+
   const { isPending: isDeletingAccount, mutate: deleteAccount } =
     api.user.deleteAccount.useMutation({
       onSuccess: () => {
@@ -25,7 +29,8 @@ export default function DeleteAccountForm({ username }: { username: string }) {
     });
 
   const handleDelete = () => {
-    deleteAccount({ confirm: username });
+    if (!confirmationMatches) return;
+    deleteAccount({ confirm: confirmValue });
   };
 
   return (
@@ -49,9 +54,11 @@ export default function DeleteAccountForm({ username }: { username: string }) {
           data-testid="delete-account-input"
           name="confirm"
           type="text"
-          required
-          pattern={username}
+          autoComplete="off"
+          value={confirmValue}
+          onChange={(e) => setConfirmValue(e.target.value)}
           placeholder={username}
+          aria-invalid={confirmValue.length > 0 && !confirmationMatches}
           className="w-full max-w-md rounded-md border border-stone-300 text-sm text-stone-900 placeholder-stone-300 focus:border-stone-500 focus:outline-none focus:ring-stone-500    "
         />
       </div>
@@ -60,22 +67,26 @@ export default function DeleteAccountForm({ username }: { username: string }) {
         <p className="w-full text-sm text-stone-500 ">
           This action is irreversible. Please proceed with caution.
         </p>
-        <FormButton pending={isDeletingAccount} />
+        <FormButton
+          pending={isDeletingAccount}
+          disabled={!confirmationMatches}
+        />
       </div>
     </form>
   );
 }
 
-function FormButton({ pending = false }) {
+function FormButton({ pending = false, disabled = false }) {
+  const inactive = pending || disabled;
   return (
     <button
       className={clsx(
         'flex h-8 min-w-32 text-nowrap items-center justify-center px-4 rounded-md border text-sm transition-all focus:outline-none sm:h-10',
-        pending
+        inactive
           ? 'cursor-not-allowed border-stone-200 bg-stone-100 text-stone-400   '
           : 'border-red-600 bg-red-600 text-white hover:bg-white hover:text-red-600 ',
       )}
-      disabled={pending}
+      disabled={inactive}
     >
       {pending ? <LoadingDots color="#808080" /> : <p>Confirm Delete</p>}
     </button>

--- a/apps/flowershow/emails/premium-downgrade.tsx
+++ b/apps/flowershow/emails/premium-downgrade.tsx
@@ -64,7 +64,7 @@ Thanks for being with us — we really appreciate that you gave Flowershow a try
           p: { fontSize: '16px', lineHeight: '26px', color: '#484848' },
         }}
       >
-        {`If you cancelled because something was missing, too limited, too expensive, or just not the right fit, I'd genuinely love to hear it. You can simply reply to this email — every reply goes to a real person and helps us improve Flowershow.
+        {`If you cancelled because something was missing, too limited, too expensive, or just not the right fit, we'd genuinely love to hear it. You can simply reply to this email — every reply goes to a real person and helps us improve Flowershow.
 
 And if you decide to keep using Flowershow, that's wonderful too.
 

--- a/apps/flowershow/emails/premium-expired.tsx
+++ b/apps/flowershow/emails/premium-expired.tsx
@@ -1,0 +1,46 @@
+import { Button, Markdown } from '@react-email/components';
+import { EmailLayout } from './components/email-layout';
+
+interface PremiumExpiredEmailProps {
+  userName: string;
+  siteName: string;
+  reactivateUrl: string;
+}
+
+const paragraphStyles = {
+  p: { fontSize: '16px', lineHeight: '26px', color: '#484848' },
+  link: { color: '#000000', textDecoration: 'underline' },
+} as const;
+
+export function PremiumExpiredEmail({
+  userName = 'there',
+  siteName = 'your site',
+  reactivateUrl = 'https://my.flowershow.app',
+}: PremiumExpiredEmailProps) {
+  return (
+    <EmailLayout
+      previewText={`Your Flowershow Premium for ${siteName} has expired`}
+    >
+      <Markdown markdownCustomStyles={paragraphStyles}>
+        {`Hi ${userName},
+
+Because we weren't able to process your payment, the Flowershow Premium subscription for **${siteName}** has now expired and the site has reverted to the Free plan.
+
+This isn't a cancellation on your part — it happened automatically after the payment retries didn't succeed. If you'd still like to keep Premium, you can reactivate anytime and get your custom domain, branding-free sites, and full-text search back:`}
+      </Markdown>
+      <Button
+        className="bg-black rounded-md text-white text-base text-center block py-3 px-6 my-6"
+        href={reactivateUrl}
+      >
+        Reactivate Premium
+      </Button>
+      <Markdown markdownCustomStyles={paragraphStyles}>
+        {`If you think this was a mistake, just reply to this email and we'll help sort it out.
+
+— The Flowershow team`}
+      </Markdown>
+    </EmailLayout>
+  );
+}
+
+export default PremiumExpiredEmail;

--- a/apps/flowershow/emails/renewal-reminder.tsx
+++ b/apps/flowershow/emails/renewal-reminder.tsx
@@ -1,0 +1,52 @@
+import { Button, Markdown } from '@react-email/components';
+import { EmailLayout } from './components/email-layout';
+
+interface RenewalReminderEmailProps {
+  userName: string;
+  siteName: string;
+  renewalDate: string;
+  amount: string;
+  manageBillingUrl: string;
+}
+
+const paragraphStyles = {
+  p: { fontSize: '16px', lineHeight: '26px', color: '#484848' },
+  link: { color: '#000000', textDecoration: 'underline' },
+} as const;
+
+export function RenewalReminderEmail({
+  userName = 'there',
+  siteName = 'your site',
+  renewalDate = 'soon',
+  amount = '$50.00',
+  manageBillingUrl = 'https://my.flowershow.app',
+}: RenewalReminderEmailProps) {
+  return (
+    <EmailLayout
+      previewText={`Your Flowershow Premium annual plan for ${siteName} renews soon`}
+    >
+      <Markdown markdownCustomStyles={paragraphStyles}>
+        {`Hi ${userName},
+
+This is a friendly heads-up that your annual Flowershow Premium plan for **${siteName}** is about to renew.
+
+We'll charge ${amount} to your card on file on ${renewalDate}, and your Premium features will continue without interruption.
+
+You don't need to do anything to stay subscribed. If you'd like to update your payment method, switch plans, or cancel before you're charged, you can manage everything here:`}
+      </Markdown>
+      <Button
+        className="bg-black rounded-md text-white text-base text-center block py-3 px-6 my-6"
+        href={manageBillingUrl}
+      >
+        Manage billing
+      </Button>
+      <Markdown markdownCustomStyles={paragraphStyles}>
+        {`Thanks for being a Flowershow Premium subscriber — we're grateful for your support.
+
+— The Flowershow team`}
+      </Markdown>
+    </EmailLayout>
+  );
+}
+
+export default RenewalReminderEmail;

--- a/apps/flowershow/lib/email.ts
+++ b/apps/flowershow/lib/email.ts
@@ -11,6 +11,7 @@ interface SendEmailOptions {
   subject: string;
   react: ReactElement;
   from?: string;
+  idempotencyKey?: string;
 }
 
 export async function sendEmail({
@@ -18,11 +19,15 @@ export async function sendEmail({
   subject,
   react,
   from = FROM_DEFAULT,
+  idempotencyKey,
 }: SendEmailOptions) {
-  return resend.emails.send({
-    from,
-    to,
-    subject,
-    react,
-  });
+  return resend.emails.send(
+    {
+      from,
+      to,
+      subject,
+      react,
+    },
+    idempotencyKey ? { idempotencyKey } : undefined,
+  );
 }

--- a/apps/flowershow/lib/transactional-email.ts
+++ b/apps/flowershow/lib/transactional-email.ts
@@ -1,0 +1,89 @@
+import type { ReactElement } from 'react';
+import { sendEmail } from '@/lib/email';
+import { log, SeverityNumber } from '@/lib/otel-logger';
+import PostHogClient from '@/lib/server-posthog';
+
+interface SendTransactionalEmailParams {
+  /** Recipient address. */
+  to: string;
+  subject: string;
+  react: ReactElement;
+  /** Machine-readable email type, for the PostHog event (e.g. 'renewal_reminder'). */
+  type: string;
+  /** Owning user id, when known — used as the default PostHog distinctId. */
+  userId?: string | null;
+  /**
+   * Stable idempotency key. Passed straight to Resend, which suppresses a
+   * duplicate send under the same key for 24h — so a redelivered webhook becomes
+   * a no-op with no first-party bookkeeping. Omit for one-shot emails that can't
+   * be redelivered.
+   */
+  idempotencyKey?: string;
+  /** distinctId for the PostHog analytics event. Defaults to userId. */
+  distinctId?: string;
+  /** Extra properties for the PostHog event. */
+  properties?: Record<string, string | number | boolean | null | undefined>;
+}
+
+export interface SendTransactionalEmailResult {
+  /** True when the send succeeded (or was a Resend-deduped no-op). */
+  sent: boolean;
+}
+
+/**
+ * Send a transactional email without ever throwing.
+ *
+ * Billing/webhook callers must return 2xx promptly to avoid Stripe retry storms,
+ * so a send failure is logged + captured in PostHog rather than propagated.
+ * Idempotency is delegated to Resend via `idempotencyKey`; observability is the
+ * `transactional_email_sent` PostHog event plus otel logs.
+ */
+export async function sendTransactionalEmail(
+  params: SendTransactionalEmailParams,
+): Promise<SendTransactionalEmailResult> {
+  const {
+    to,
+    subject,
+    react,
+    type,
+    userId,
+    idempotencyKey,
+    distinctId,
+    properties,
+  } = params;
+
+  try {
+    const result = await sendEmail({ to, subject, react, idempotencyKey });
+    // Resend surfaces API errors on the `error` field rather than throwing.
+    if ((result as { error?: unknown } | undefined)?.error) {
+      throw new Error(
+        `Resend error: ${JSON.stringify((result as { error?: unknown }).error)}`,
+      );
+    }
+
+    const posthog = PostHogClient();
+    posthog.capture({
+      distinctId: distinctId ?? userId ?? 'system',
+      event: 'transactional_email_sent',
+      properties: { email_type: type, ...properties },
+    });
+    await posthog.shutdown();
+
+    return { sent: true };
+  } catch (err) {
+    // Record the failure without blocking the caller.
+    log(`Transactional email send failed: ${type}`, SeverityNumber.ERROR, {
+      email_type: type,
+      userId: userId ?? undefined,
+    });
+
+    const posthog = PostHogClient();
+    posthog.captureException(err, distinctId ?? userId ?? 'system', {
+      context: 'transactional_email',
+      email_type: type,
+    });
+    await posthog.shutdown();
+
+    return { sent: false };
+  }
+}

--- a/apps/flowershow/server/__tests__/auth-magic-link.test.ts
+++ b/apps/flowershow/server/__tests__/auth-magic-link.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mocks (hoisted above the imports they affect) ─────────────────
+
+const { sendEmailMock, captureExceptionMock } = vi.hoisted(() => ({
+  sendEmailMock: vi.fn(),
+  captureExceptionMock: vi.fn(),
+}));
+
+vi.mock('@/lib/email', () => ({ sendEmail: sendEmailMock }));
+
+vi.mock('@/lib/server-posthog', () => ({
+  default: () => ({
+    capture: vi.fn(),
+    captureException: captureExceptionMock,
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  }),
+  __esModule: true,
+}));
+
+vi.mock('@/server/db', () => ({
+  default: {
+    // No recent token => magic-link cooldown does not apply, so the send runs.
+    verificationToken: { findFirst: vi.fn().mockResolvedValue(null) },
+  },
+}));
+
+// ── Imports ───────────────────────────────────────────────────────
+
+import { authOptions } from '@/server/auth';
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+function getSendVerificationRequest() {
+  const provider = authOptions.providers.find(
+    (p: any) => p.id === 'email',
+  ) as any;
+  // NextAuth keeps our custom callback on `.options`; the top-level
+  // `sendVerificationRequest` is its own default wrapper.
+  return (
+    provider.options?.sendVerificationRequest ??
+    provider.sendVerificationRequest
+  );
+}
+
+function callArgs() {
+  return {
+    identifier: 'ada@example.com',
+    url: 'https://flowershow.app/verify?token=abc',
+    expires: new Date(Date.now() + 24 * 60 * 60 * 1000),
+  } as any;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('sendVerificationRequest (magic-link hardening)', () => {
+  it('sends the magic-link email and resolves on success', async () => {
+    sendEmailMock.mockResolvedValue({ data: { id: 'e1' }, error: null });
+    const send = getSendVerificationRequest();
+
+    await expect(send(callArgs())).resolves.toBeUndefined();
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(sendEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({ to: 'ada@example.com' }),
+    );
+  });
+
+  it('retries once on a transient failure and then succeeds', async () => {
+    sendEmailMock
+      .mockRejectedValueOnce(new Error('network blip'))
+      .mockResolvedValueOnce({ data: { id: 'e1' }, error: null });
+    const send = getSendVerificationRequest();
+
+    await expect(send(callArgs())).resolves.toBeUndefined();
+    expect(sendEmailMock).toHaveBeenCalledTimes(2);
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it('throws (surfacing to the UI) and captures the error after all retries fail', async () => {
+    sendEmailMock.mockRejectedValue(new Error('resend down'));
+    const send = getSendVerificationRequest();
+
+    await expect(send(callArgs())).rejects.toThrow(
+      'Failed to send magic-link email',
+    );
+    expect(sendEmailMock).toHaveBeenCalledTimes(2);
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a Resend error-field response as a failure and surfaces it', async () => {
+    sendEmailMock.mockResolvedValue({
+      data: null,
+      error: { name: 'rate_limit_exceeded', message: 'slow down' },
+    });
+    const send = getSendVerificationRequest();
+
+    await expect(send(callArgs())).rejects.toThrow(
+      'Failed to send magic-link email',
+    );
+    expect(sendEmailMock).toHaveBeenCalledTimes(2);
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/flowershow/server/api/routers/__tests__/user.test.ts
+++ b/apps/flowershow/server/api/routers/__tests__/user.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mocks (must come before imports that depend on them) ──────────
+
+vi.mock('next/cache', () => ({
+  unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
+  revalidateTag: vi.fn(),
+}));
+
+vi.mock('@/server/auth', () => ({
+  getSession: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('@/server/db', () => ({ db: {} }));
+vi.mock('@/lib/stripe', () => ({ stripe: {} }));
+vi.mock('@/lib/typesense', () => ({ deleteSiteCollection: vi.fn() }));
+vi.mock('@/lib/server-posthog', () => {
+  const client = {
+    capture: vi.fn(),
+    captureException: vi.fn(),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  };
+  return { default: () => client, __esModule: true };
+});
+vi.mock('@/lib/domains', () => ({
+  addDomainToVercel: vi.fn(),
+  removeDomainAndVariantFromVercelProject: vi.fn(),
+  validDomainRegex: /./,
+}));
+vi.mock('@/lib/github', () => ({
+  fetchGitHubScopes: vi.fn(),
+  fetchGitHubScopeRepositories: vi.fn(),
+}));
+
+// Email delivery is exercised end-to-end in the webhook idempotency tests; here
+// we assert the mutation delegates to the transactional-email seam correctly.
+vi.mock('@/lib/transactional-email', () => ({
+  sendTransactionalEmail: vi.fn().mockResolvedValue({ sent: true }),
+}));
+
+// ── Imports ───────────────────────────────────────────────────────
+
+import { appRouter } from '@/server/api/root';
+import { sendTransactionalEmail } from '@/lib/transactional-email';
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+function makeDb(user: unknown) {
+  return {
+    user: {
+      findUnique: vi.fn().mockResolvedValue(user),
+      delete: vi.fn().mockResolvedValue({}),
+    },
+  };
+}
+
+function createCaller(db: unknown) {
+  return appRouter.createCaller({
+    session: { user: { id: 'user-1' }, expires: '' } as any,
+    db: db as any,
+    headers: new Headers(),
+  });
+}
+
+const USER = {
+  username: 'ada',
+  name: 'Ada Lovelace',
+  email: 'ada@example.com',
+  sites: [] as unknown[],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('user.deleteAccount', () => {
+  it('sends the account-deletion confirmation to the right address after deleting', async () => {
+    const db = makeDb(USER);
+    const caller = createCaller(db);
+
+    const result = await caller.user.deleteAccount({ confirm: 'ada' });
+
+    expect(result).toEqual({ success: true });
+    expect(db.user.delete).toHaveBeenCalledWith({ where: { id: 'user-1' } });
+    expect(sendTransactionalEmail).toHaveBeenCalledTimes(1);
+    expect(sendTransactionalEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'ada@example.com',
+        type: 'account_deleted',
+        idempotencyKey: 'account-deleted:user-1',
+      }),
+    );
+  });
+
+  it('does not delete or email when the confirmation does not match the username', async () => {
+    const db = makeDb(USER);
+    const caller = createCaller(db);
+
+    await expect(
+      caller.user.deleteAccount({ confirm: 'wrong' }),
+    ).rejects.toThrow('Confirmation does not match username');
+
+    expect(db.user.delete).not.toHaveBeenCalled();
+    expect(sendTransactionalEmail).not.toHaveBeenCalled();
+  });
+
+  it('blocks deletion (and sends nothing) when a site has an active subscription', async () => {
+    const db = makeDb({
+      ...USER,
+      sites: [
+        {
+          id: 's1',
+          projectName: 'my-site',
+          subscription: { status: 'active' },
+        },
+      ],
+    });
+    const caller = createCaller(db);
+
+    await expect(caller.user.deleteAccount({ confirm: 'ada' })).rejects.toThrow(
+      /active subscription/,
+    );
+
+    expect(db.user.delete).not.toHaveBeenCalled();
+    expect(sendTransactionalEmail).not.toHaveBeenCalled();
+  });
+});

--- a/apps/flowershow/server/api/routers/user.ts
+++ b/apps/flowershow/server/api/routers/user.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod';
+import { AccountDeletedEmail } from '@/emails/account-deleted';
 import { ANONYMOUS_USER_ID } from '@/lib/anonymous-user';
 import { fetchGitHubScopeRepositories, fetchGitHubScopes } from '@/lib/github';
 import PostHogClient from '@/lib/server-posthog';
+import { sendTransactionalEmail } from '@/lib/transactional-email';
 import {
   createTRPCRouter,
   protectedProcedure,
@@ -185,6 +187,8 @@ export const userRouter = createTRPCRouter({
         where: { id: userId },
         select: {
           username: true,
+          name: true,
+          email: true,
           sites: {
             select: {
               id: true,
@@ -219,6 +223,11 @@ export const userRouter = createTRPCRouter({
         );
       }
 
+      // Capture the address before the row is gone — the confirmation is sent
+      // after the delete transaction commits.
+      const deletedUserEmail = user.email;
+      const deletedUserName = user.name?.split(' ')[0] || user.username;
+
       // Delete user (cascades to all relations per schema)
       await ctx.db.user.delete({
         where: { id: userId },
@@ -230,6 +239,18 @@ export const userRouter = createTRPCRouter({
         event: 'account_deleted',
       });
       await posthog.shutdown();
+
+      if (deletedUserEmail) {
+        await sendTransactionalEmail({
+          to: deletedUserEmail,
+          subject: 'Your Flowershow account has been deleted',
+          react: AccountDeletedEmail({ userName: deletedUserName }),
+          type: 'account_deleted',
+          userId,
+          idempotencyKey: `account-deleted:${userId}`,
+          distinctId: userId,
+        });
+      }
 
       return { success: true };
     }),

--- a/apps/flowershow/server/auth.ts
+++ b/apps/flowershow/server/auth.ts
@@ -95,11 +95,42 @@ export const authOptions: NextAuthOptions = {
           return;
         }
 
-        await sendEmail({
-          to: email,
-          subject: 'Your Flowershow sign-in link',
-          react: MagicLinkEmail({ url }),
+        // Sign-in is blocked on this email actually going out, so unlike our
+        // best-effort emails we retry transient failures and, if it still
+        // fails, throw — NextAuth then routes to the error page instead of
+        // showing a false "check your email". The failure is tracked so the
+        // team has a signal too.
+        const MAX_ATTEMPTS = 2;
+        let lastError: unknown;
+        for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+          try {
+            const result = await sendEmail({
+              to: email,
+              subject: 'Your Flowershow sign-in link',
+              react: MagicLinkEmail({ url }),
+            });
+            // Resend reports API errors on `error` rather than throwing.
+            if (result?.error) {
+              throw new Error(`Resend error: ${JSON.stringify(result.error)}`);
+            }
+            return; // delivered
+          } catch (err) {
+            lastError = err;
+            console.error(
+              `Magic-link send attempt ${attempt}/${MAX_ATTEMPTS} failed for ${email}:`,
+              err,
+            );
+          }
+        }
+
+        const posthog = PostHogClient();
+        posthog.captureException(lastError, 'system', {
+          context: 'magic_link_send',
+          provider: 'resend',
         });
+        await posthog.shutdown();
+
+        throw new Error('Failed to send magic-link email');
       },
     }),
   ],


### PR DESCRIPTION
## What

Adds transactional emails for the billing lifecycle, plus supporting hardening. Implements flowershow/product#15.

Flowershow sends only the emails Stripe does **not**:
- **Renewal reminder** (`invoice.upcoming`, annual plans only) — heads-up before the yearly charge.
- **Premium expired** (subscription cancelled with `cancellation_details.reason === 'payment_failure'`) — involuntary-expiry notice with a reactivate link.
- **Account deleted** — one-shot confirmation on account deletion.

Both billing emails **name the affected site** (`projectName`) in the subject preview and body, since each subscription maps to one site.

## Also included

- **`lib/transactional-email.ts`** — a never-throws wrapper (send → detect Resend `.error` → PostHog event → capture on failure) so webhook handlers return 2xx promptly and avoid Stripe retry storms.
- **Magic-link send hardening** (`server/auth.ts`) — 2 attempts, throws on persistent failure so NextAuth routes to the error page instead of showing a false "check your email", with PostHog capture.

## Testing

- `app/api/stripe/webhook/route.test.ts` — renewal/expiry split, idempotency key, yearly-only gating, and that each email names the specific site.
- `server/__tests__/auth-magic-link.test.ts`, `server/api/routers/__tests__/user.test.ts`, `__tests__/lib/email.test.ts`.
- Full unit suite: **432 passing**. ESLint + `tsc --noEmit` clean.

## Human action items (Stripe Dashboard — can't be automated)

- **Leave ON:** finalised invoices/credit notes, expiring-card emails, card/bank payment-failure emails (Stripe owns dunning).
- **Verify OFF:** any Stripe "upcoming renewal reminder" email (would collide with our `renewal_reminder`).
- Enable **Smart Retries** if not already.
- Test-mode: `stripe trigger invoice.payment_failed` → confirm the customer gets **exactly one** email (Stripe's).

Closes flowershow/product#15
