### PR TITLE
feat(worker): capture runtime errors from entrypoints & workflows in PostHog

### DIFF
--- a/apps/cloudflare-worker/src/github-sync-workflow.js
+++ b/apps/cloudflare-worker/src/github-sync-workflow.js
@@ -7,7 +7,7 @@ import {
   getGitHubInstallationToken,
 } from './github.js';
 import { deleteFile, uploadFile } from './storage.js';
-import { generateId } from './utils.js';
+import { captureError, generateId } from './utils.js';
 
 const BATCH_SIZE = 20;
 
@@ -24,126 +24,138 @@ export class GitHubSyncWorkflow extends WorkflowEntrypoint {
       gitCommitMessage = null,
     } = event.payload;
 
-    // Generate a fresh token on every run (outside any step so retries don't reuse
-    // a cached expired value — GitHub App installation tokens expire in 1h).
-    const accessToken = await getGitHubInstallationToken(
-      githubInstallationId,
-      this.env,
-    );
+    try {
+      // Generate a fresh token on every run (outside any step so retries don't reuse
+      // a cached expired value — GitHub App installation tokens expire in 1h).
+      const accessToken = await getGitHubInstallationToken(
+        githubInstallationId,
+        this.env,
+      );
 
-    const sql = getPostgresClient(this.env);
-    const storage = getStorageClient(this.env);
+      const sql = getPostgresClient(this.env);
+      const storage = getStorageClient(this.env);
 
-    // Verify site exists
-    await step.do('fetch-site', async () => {
-      const rows = await sql`SELECT id FROM "Site" WHERE id = ${siteId}`;
-      if (rows.length === 0) throw new Error(`Site ${siteId} not found.`);
-    });
+      // Verify site exists
+      await step.do('fetch-site', async () => {
+        const rows = await sql`SELECT id FROM "Site" WHERE id = ${siteId}`;
+        if (rows.length === 0) throw new Error(`Site ${siteId} not found.`);
+      });
 
-    // Create the Publish record
-    await step.do('create-publish-record', async () => {
-      await sql`
+      // Create the Publish record
+      await step.do('create-publish-record', async () => {
+        await sql`
         INSERT INTO "Publish" (id, site_id, source, started_at, git_commit_sha, git_commit_message)
         VALUES (${publishId}, ${siteId}, 'github_webhook', NOW(), ${gitCommitSha}, ${gitCommitMessage})
       `;
-    });
-
-    // Fetch site config (contentInclude / contentExclude)
-    const { contentInclude: includes = [], contentExclude: excludes = [] } =
-      await step.do('fetch-site-config', async () => {
-        return fetchGitHubConfig(ghRepository, ghBranch, accessToken, rootDir);
       });
 
-    // Fetch GitHub repo tree — strip to only the fields used downstream (path,
-    // type, sha) to stay within the Workflows 1 MiB step-output limit.
-    const gitHubTree = await step.do('fetch-github-tree', async () => {
-      const full = await fetchGitHubRepoTree(ghRepository, ghBranch, accessToken);
-      return { tree: full.tree.map(({ path, type, sha }) => ({ path, type, sha })) };
-    });
+      // Fetch site config (contentInclude / contentExclude)
+      const { contentInclude: includes = [], contentExclude: excludes = [] } =
+        await step.do('fetch-site-config', async () => {
+          return fetchGitHubConfig(
+            ghRepository,
+            ghBranch,
+            accessToken,
+            rootDir,
+          );
+        });
 
-    const normalizedRoot = normalizeRootDir(rootDir);
+      // Fetch GitHub repo tree — strip to only the fields used downstream (path,
+      // type, sha) to stay within the Workflows 1 MiB step-output limit.
+      const gitHubTree = await step.do('fetch-github-tree', async () => {
+        const full = await fetchGitHubRepoTree(
+          ghRepository,
+          ghBranch,
+          accessToken,
+        );
+        return {
+          tree: full.tree.map(({ path, type, sha }) => ({ path, type, sha })),
+        };
+      });
 
-    // Determine which files need to be upserted — store only the fields used
-    // during processing (ghPath/ghSha for download, filePath/changeType for DB)
-    // to keep step output small.
-    const fileBatchesToUpsert = await step.do(
-      'get-file-batches-to-upsert',
-      async () => {
-        const existingBlobs = await sql`
+      const normalizedRoot = normalizeRootDir(rootDir);
+
+      // Determine which files need to be upserted — store only the fields used
+      // during processing (ghPath/ghSha for download, filePath/changeType for DB)
+      // to keep step output small.
+      const fileBatchesToUpsert = await step.do(
+        'get-file-batches-to-upsert',
+        async () => {
+          const existingBlobs = await sql`
           SELECT path, sha FROM "Blob" WHERE site_id = ${siteId}
         `;
-        const items = computeFilesToUpsert(
-          existingBlobs,
-          gitHubTree,
-          normalizedRoot,
-          includes,
-          excludes,
-        );
-        return createBatches(
-          items.map(({ ghTreeItem, filePath, changeType }) => ({
-            ghPath: ghTreeItem.path,
-            ghSha: ghTreeItem.sha,
-            filePath,
-            changeType,
-          })),
-          BATCH_SIZE,
-        );
-      },
-    );
+          const items = computeFilesToUpsert(
+            existingBlobs,
+            gitHubTree,
+            normalizedRoot,
+            includes,
+            excludes,
+          );
+          return createBatches(
+            items.map(({ ghTreeItem, filePath, changeType }) => ({
+              ghPath: ghTreeItem.path,
+              ghSha: ghTreeItem.sha,
+              filePath,
+              changeType,
+            })),
+            BATCH_SIZE,
+          );
+        },
+      );
 
-    // Determine which files should be deleted
-    const fileBatchesToDelete = await step.do(
-      'get-file-batches-to-delete',
-      async () => {
-        const existingBlobs = await sql`
+      // Determine which files should be deleted
+      const fileBatchesToDelete = await step.do(
+        'get-file-batches-to-delete',
+        async () => {
+          const existingBlobs = await sql`
           SELECT path FROM "Blob" WHERE site_id = ${siteId}
         `;
-        const toDelete = computeFilesToDelete(
-          existingBlobs,
-          gitHubTree,
-          normalizedRoot,
-          includes,
-          excludes,
-        );
-        return createBatches(toDelete, BATCH_SIZE);
-      },
-    );
+          const toDelete = computeFilesToDelete(
+            existingBlobs,
+            gitHubTree,
+            normalizedRoot,
+            includes,
+            excludes,
+          );
+          return createBatches(toDelete, BATCH_SIZE);
+        },
+      );
 
-    // Create PublishFile rows for all files to upsert
-    await step.do('create-publish-files-for-upsert', async () => {
-      const allItems = fileBatchesToUpsert.flat();
-      if (allItems.length === 0) return;
-      for (const { filePath, changeType } of allItems) {
-        await sql`
+      // Create PublishFile rows for all files to upsert
+      await step.do('create-publish-files-for-upsert', async () => {
+        const allItems = fileBatchesToUpsert.flat();
+        if (allItems.length === 0) return;
+        for (const { filePath, changeType } of allItems) {
+          await sql`
           INSERT INTO "PublishFile" (id, publish_id, path, change_type, status)
           VALUES (${generateId()}, ${publishId}, ${filePath}, ${changeType}, 'uploading')
         `;
-      }
-    });
+        }
+      });
 
-    // Delete file batches from R2; create terminal PublishFile rows for each deletion.
-    // Worker handles Blob/Typesense cleanup via DeleteObject events.
-    await Promise.all(
-      fileBatchesToDelete.map((batch, index) =>
-        step.do(`delete-files-batch-${index}`, async () => {
-          const deletedPaths = [];
+      // Delete file batches from R2; create terminal PublishFile rows for each deletion.
+      // Worker handles Blob/Typesense cleanup via DeleteObject events.
+      await Promise.all(
+        fileBatchesToDelete.map((batch, index) =>
+          step.do(`delete-files-batch-${index}`, async () => {
+            const deletedPaths = [];
 
-          await Promise.all(
-            batch.map(async (blob) => {
-              try {
-                await deleteFile(storage, siteId, ghBranch, blob.path);
-                deletedPaths.push(blob.path);
-              } catch (err) {
-                console.error(
-                  `Storage deletion failed ${siteId}/${blob.path}: ${err.message}`,
-                );
-              }
-            }),
-          );
+            await Promise.all(
+              batch.map(async (blob) => {
+                try {
+                  await deleteFile(storage, siteId, ghBranch, blob.path);
+                  deletedPaths.push(blob.path);
+                } catch (err) {
+                  console.error(
+                    `Storage deletion failed ${siteId}/${blob.path}: ${err.message}`,
+                  );
+                }
+              }),
+            );
 
-          const deletedSet = new Set(deletedPaths);
-          for (const blob of batch) {
-            await sql`
+            const deletedSet = new Set(deletedPaths);
+            for (const blob of batch) {
+              await sql`
               INSERT INTO "PublishFile" (id, publish_id, path, change_type, status)
               VALUES (
                 ${generateId()},
@@ -153,56 +165,67 @@ export class GitHubSyncWorkflow extends WorkflowEntrypoint {
                 ${deletedSet.has(blob.path) ? 'success' : 'error'}
               )
             `;
-          }
+            }
 
-          return deletedPaths;
-        }),
-      ),
-    );
+            return deletedPaths;
+          }),
+        ),
+      );
 
-    // Start the finalizer after all PublishFile rows exist (uploading + terminal).
-    // The finalizer polls until all uploading rows reach a terminal state, then
-    // finalizes the Publish record. It naturally handles the zero-files and
-    // delete-only cases without any special signaling.
-    await step.do('start-publish-finalizer', async () => {
-      await this.env.PUBLISH_FINALIZER_WORKFLOW.create({
-        id: publishId,
-        params: { publishId, siteId },
+      // Start the finalizer after all PublishFile rows exist (uploading + terminal).
+      // The finalizer polls until all uploading rows reach a terminal state, then
+      // finalizes the Publish record. It naturally handles the zero-files and
+      // delete-only cases without any special signaling.
+      await step.do('start-publish-finalizer', async () => {
+        await this.env.PUBLISH_FINALIZER_WORKFLOW.create({
+          id: publishId,
+          params: { publishId, siteId },
+        });
       });
-    });
 
-    // Download from GitHub and upload to R2 in batches
-    await Promise.all(
-      fileBatchesToUpsert.map((batch, index) =>
-        step.do(`process-files-to-upsert-batch-${index}`, async () => {
-          await Promise.all(
-            batch.map(async ({ ghPath, ghSha, filePath }) => {
-              try {
-                const extension = ghPath.split('.').pop() || '';
-                const fileBuffer = await fetchGitHubFileRaw(
-                  ghRepository,
-                  ghSha,
-                  accessToken,
-                );
-                await uploadFile(
-                  storage,
-                  siteId,
-                  ghBranch,
-                  filePath,
-                  fileBuffer,
-                  extension,
-                  publishId,
-                );
-              } catch (error) {
-                console.error(
-                  `Sync file error ${siteId}/${filePath}: ${error.message}`,
-                );
-              }
-            }),
-          );
-        }),
-      ),
-    );
+      // Download from GitHub and upload to R2 in batches
+      await Promise.all(
+        fileBatchesToUpsert.map((batch, index) =>
+          step.do(`process-files-to-upsert-batch-${index}`, async () => {
+            await Promise.all(
+              batch.map(async ({ ghPath, ghSha, filePath }) => {
+                try {
+                  const extension = ghPath.split('.').pop() || '';
+                  const fileBuffer = await fetchGitHubFileRaw(
+                    ghRepository,
+                    ghSha,
+                    accessToken,
+                  );
+                  await uploadFile(
+                    storage,
+                    siteId,
+                    ghBranch,
+                    filePath,
+                    fileBuffer,
+                    extension,
+                    publishId,
+                  );
+                } catch (error) {
+                  console.error(
+                    `Sync file error ${siteId}/${filePath}: ${error.message}`,
+                  );
+                }
+              }),
+            );
+          }),
+        ),
+      );
+    } catch (err) {
+      await captureError(this.env, {
+        source: 'workflow_github_sync',
+        siteId,
+        publishId,
+        error_message: err?.message,
+        error_name: err?.name,
+        error_stack: err?.stack,
+      });
+      throw err;
+    }
   }
 }
 

--- a/apps/cloudflare-worker/src/publish-finalizer-workflow.js
+++ b/apps/cloudflare-worker/src/publish-finalizer-workflow.js
@@ -1,6 +1,7 @@
 import { WorkflowEntrypoint } from 'cloudflare:workers';
 import { matchLinkTarget } from '@flowershow/core';
 import { getPostgresClient } from './clients.js';
+import { captureError } from './utils.js';
 
 const MAX_POLL_ATTEMPTS = 360; // 1 hour at 10s intervals
 
@@ -8,73 +9,89 @@ export class PublishFinalizerWorkflow extends WorkflowEntrypoint {
   async run(event, step) {
     const { publishId, siteId } = event.payload;
 
-    const sql = getPostgresClient(this.env);
+    try {
+      const sql = getPostgresClient(this.env);
 
-    let timedOut = false;
-    for (let i = 0; i < MAX_POLL_ATTEMPTS; i++) {
-      const done = await step.do(`check-completion-${i}`, async () => {
-        const [{ count }] = await sql`
+      let timedOut = false;
+      for (let i = 0; i < MAX_POLL_ATTEMPTS; i++) {
+        const done = await step.do(`check-completion-${i}`, async () => {
+          const [{ count }] = await sql`
           SELECT COUNT(*) AS count FROM "PublishFile"
           WHERE publish_id = ${publishId} AND status = 'uploading'
         `;
-        return Number(count) === 0;
-      });
-      if (done) break;
-      if (i === MAX_POLL_ATTEMPTS - 1) {
-        timedOut = true;
-      } else {
-        await step.sleep(`poll-interval-${i}`, '10 seconds');
+          return Number(count) === 0;
+        });
+        if (done) break;
+        if (i === MAX_POLL_ATTEMPTS - 1) {
+          timedOut = true;
+        } else {
+          await step.sleep(`poll-interval-${i}`, '10 seconds');
+        }
       }
-    }
 
-    await step.do('finalize-publish', () =>
-      finalizePublish({ sql, publishId, timedOut }),
-    );
+      await step.do('finalize-publish', () =>
+        finalizePublish({ sql, publishId, timedOut }),
+      );
 
-    await step.do('resolve-links', async () => {
-      const unresolved = await sql`
+      await step.do('resolve-links', async () => {
+        const unresolved = await sql`
         SELECT id, target_path FROM "Link"
         WHERE site_id = ${siteId} AND target_blob_id IS NULL
       `;
-      if (unresolved.length === 0) return;
+        if (unresolved.length === 0) return;
 
-      const blobs = /** @type {{ id: string, path: string }[]} */ (await sql`
+        const blobs = /** @type {{ id: string, path: string }[]} */ (
+          await sql`
         SELECT id, path, app_path, permalink FROM "Blob"
         WHERE site_id = ${siteId}
-      `);
+      `
+        );
 
-      for (const link of unresolved) {
-        const match = matchLinkTarget(link.target_path, blobs);
-        if (match) {
-          await sql`
+        for (const link of unresolved) {
+          const match = matchLinkTarget(link.target_path, blobs);
+          if (match) {
+            await sql`
             UPDATE "Link" SET target_blob_id = ${match.id}
             WHERE id = ${link.id}
           `;
+          }
         }
-      }
-    });
+      });
 
-    await step.do('revalidate-tags', async () => {
-      if (!this.env.NEXTJS_APP_URL || !this.env.INTERNAL_API_SECRET) return;
-      try {
-        const resp = await fetch(
-          `${this.env.NEXTJS_APP_URL}/api/internal/revalidate`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'x-internal-secret': this.env.INTERNAL_API_SECRET,
+      await step.do('revalidate-tags', async () => {
+        if (!this.env.NEXTJS_APP_URL || !this.env.INTERNAL_API_SECRET) return;
+        try {
+          const resp = await fetch(
+            `${this.env.NEXTJS_APP_URL}/api/internal/revalidate`,
+            {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'x-internal-secret': this.env.INTERNAL_API_SECRET,
+              },
+              body: JSON.stringify({ tags: [siteId] }),
             },
-            body: JSON.stringify({ tags: [siteId] }),
-          },
-        );
-        if (!resp.ok) {
-          console.error(`Revalidate failed: ${resp.status} for site ${siteId}`);
+          );
+          if (!resp.ok) {
+            console.error(
+              `Revalidate failed: ${resp.status} for site ${siteId}`,
+            );
+          }
+        } catch (err) {
+          console.error(`Revalidate error for site ${siteId}: ${err.message}`);
         }
-      } catch (err) {
-        console.error(`Revalidate error for site ${siteId}: ${err.message}`);
-      }
-    });
+      });
+    } catch (err) {
+      await captureError(this.env, {
+        source: 'workflow_publish_finalizer',
+        siteId,
+        publishId,
+        error_message: err?.message,
+        error_name: err?.name,
+        error_stack: err?.stack,
+      });
+      throw err;
+    }
   }
 }
 

--- a/apps/cloudflare-worker/src/utils.js
+++ b/apps/cloudflare-worker/src/utils.js
@@ -1,4 +1,3 @@
-
 export function generateId() {
   const timestamp = Date.now().toString(36);
   const random = crypto.randomUUID().replace(/-/g, '').substring(0, 16);

--- a/apps/cloudflare-worker/src/worker.js
+++ b/apps/cloudflare-worker/src/worker.js
@@ -8,188 +8,222 @@ import { GitHubSyncWorkflow } from './github-sync-workflow.js';
 import { PublishFinalizerWorkflow } from './publish-finalizer-workflow.js';
 import { handleMessage } from './queue-consumer.js';
 import { deleteSiteStorage } from './storage.js';
-import { generateId } from './utils.js';
+import { captureError, generateId } from './utils.js';
 
 export { GitHubSyncWorkflow, PublishFinalizerWorkflow };
 
 export default {
   // HTTP endpoint (health + dev adapter + sync trigger)
   async fetch(request, env, _ctx) {
-    validateEnv(env);
     const url = new URL(request.url);
+    try {
+      validateEnv(env);
 
-    // Trigger GitHub sync workflow
-    if (request.method === 'POST' && url.pathname === '/sync') {
-      const authHeader = request.headers.get('Authorization');
-      const expectedToken = `Bearer ${env.SYNC_TRIGGER_SECRET}`;
-      if (!env.SYNC_TRIGGER_SECRET || authHeader !== expectedToken) {
-        return new Response('Unauthorized', { status: 401 });
-      }
-
-      let body;
-      try {
-        body = await request.json();
-      } catch {
-        return new Response('Invalid JSON', { status: 400 });
-      }
-
-      const {
-        siteId,
-        ghRepository,
-        ghBranch,
-        rootDir,
-        githubInstallationId,
-        gitCommitSha,
-        gitCommitMessage,
-      } = body;
-      if (!siteId || !ghRepository || !ghBranch || !githubInstallationId) {
-        return new Response(
-          'Missing required fields: siteId, ghRepository, ghBranch, githubInstallationId',
-          { status: 400 },
-        );
-      }
-
-      const sql = getPostgresClient(env);
-
-      let publishId;
-      try {
-        publishId = generateId();
-
-        // Cancel all uploading files from prior in-progress publishes for this site.
-        // Their finalizers will detect completion on the next poll and set completedAt.
-        const previous = await sql`
-          SELECT id FROM "Publish"
-          WHERE site_id = ${siteId}
-            AND completed_at IS NULL
-          ORDER BY started_at DESC
-        `;
-
-        for (const prev of previous) {
-          await sql`
-            UPDATE "PublishFile" SET status = 'canceled'
-            WHERE publish_id = ${prev.id} AND status = 'uploading'
-          `;
-          // Terminate the GitHub sync workflow — no value in continuing to process an old tree.
-          try {
-            const prevSync = await env.GITHUB_SYNC_WORKFLOW.get(
-              `${prev.id}-github`,
-            );
-            await prevSync.terminate();
-          } catch (termErr) {
-            console.error(
-              `Failed to terminate sync workflow ${prev.id}: ${termErr.message}`,
-            );
-          }
+      // Trigger GitHub sync workflow
+      if (request.method === 'POST' && url.pathname === '/sync') {
+        const authHeader = request.headers.get('Authorization');
+        const expectedToken = `Bearer ${env.SYNC_TRIGGER_SECRET}`;
+        if (!env.SYNC_TRIGGER_SECRET || authHeader !== expectedToken) {
+          return new Response('Unauthorized', { status: 401 });
         }
-      } finally {
-        await sql.end();
-      }
 
-      const syncInstance = await env.GITHUB_SYNC_WORKFLOW.create({
-        id: `${publishId}-github`,
-        params: {
-          publishId,
+        let body;
+        try {
+          body = await request.json();
+        } catch {
+          return new Response('Invalid JSON', { status: 400 });
+        }
+
+        const {
           siteId,
           ghRepository,
           ghBranch,
-          rootDir: rootDir ?? null,
+          rootDir,
           githubInstallationId,
-          gitCommitSha: gitCommitSha ?? null,
-          gitCommitMessage: gitCommitMessage ?? null,
-        },
-      });
+          gitCommitSha,
+          gitCommitMessage,
+        } = body;
+        if (!siteId || !ghRepository || !ghBranch || !githubInstallationId) {
+          return new Response(
+            'Missing required fields: siteId, ghRepository, ghBranch, githubInstallationId',
+            { status: 400 },
+          );
+        }
 
-      return Response.json({ instanceId: syncInstance.id }, { status: 202 });
-    }
+        const sql = getPostgresClient(env);
 
-    // Start finalizer workflow
-    if (request.method === 'POST' && url.pathname === '/start-finalizer') {
-      const authHeader = request.headers.get('Authorization');
-      const expectedToken = `Bearer ${env.SYNC_TRIGGER_SECRET}`;
-      if (!env.SYNC_TRIGGER_SECRET || authHeader !== expectedToken) {
-        return new Response('Unauthorized', { status: 401 });
-      }
+        let publishId;
+        try {
+          publishId = generateId();
 
-      let body;
-      try {
-        body = await request.json();
-      } catch {
-        return new Response('Invalid JSON', { status: 400 });
-      }
+          // Cancel all uploading files from prior in-progress publishes for this site.
+          // Their finalizers will detect completion on the next poll and set completedAt.
+          const previous = await sql`
+            SELECT id FROM "Publish"
+            WHERE site_id = ${siteId}
+              AND completed_at IS NULL
+            ORDER BY started_at DESC
+          `;
 
-      const { publishId, siteId } = body;
-      if (!publishId || !siteId) {
-        return new Response('Missing required fields: publishId, siteId', {
-          status: 400,
+          for (const prev of previous) {
+            await sql`
+              UPDATE "PublishFile" SET status = 'canceled'
+              WHERE publish_id = ${prev.id} AND status = 'uploading'
+            `;
+            // Terminate the GitHub sync workflow — no value in continuing to process an old tree.
+            try {
+              const prevSync = await env.GITHUB_SYNC_WORKFLOW.get(
+                `${prev.id}-github`,
+              );
+              await prevSync.terminate();
+            } catch (termErr) {
+              console.error(
+                `Failed to terminate sync workflow ${prev.id}: ${termErr.message}`,
+              );
+            }
+          }
+        } finally {
+          await sql.end();
+        }
+
+        const syncInstance = await env.GITHUB_SYNC_WORKFLOW.create({
+          id: `${publishId}-github`,
+          params: {
+            publishId,
+            siteId,
+            ghRepository,
+            ghBranch,
+            rootDir: rootDir ?? null,
+            githubInstallationId,
+            gitCommitSha: gitCommitSha ?? null,
+            gitCommitMessage: gitCommitMessage ?? null,
+          },
         });
+
+        return Response.json({ instanceId: syncInstance.id }, { status: 202 });
       }
 
-      const instance = await env.PUBLISH_FINALIZER_WORKFLOW.create({
-        id: publishId,
-        params: { publishId, siteId },
+      // Start finalizer workflow
+      if (request.method === 'POST' && url.pathname === '/start-finalizer') {
+        const authHeader = request.headers.get('Authorization');
+        const expectedToken = `Bearer ${env.SYNC_TRIGGER_SECRET}`;
+        if (!env.SYNC_TRIGGER_SECRET || authHeader !== expectedToken) {
+          return new Response('Unauthorized', { status: 401 });
+        }
+
+        let body;
+        try {
+          body = await request.json();
+        } catch {
+          return new Response('Invalid JSON', { status: 400 });
+        }
+
+        const { publishId, siteId } = body;
+        if (!publishId || !siteId) {
+          return new Response('Missing required fields: publishId, siteId', {
+            status: 400,
+          });
+        }
+
+        const instance = await env.PUBLISH_FINALIZER_WORKFLOW.create({
+          id: publishId,
+          params: { publishId, siteId },
+        });
+
+        return Response.json({ instanceId: instance.id }, { status: 202 });
+      }
+
+      // Dev adapter for S3 events from Minio
+      if (env.ENVIRONMENT === 'dev' && url.pathname === '/queue') {
+        let event;
+        try {
+          event = await request.json();
+        } catch {
+          return new Response('Invalid JSON', { status: 400 });
+        }
+        const record = event.Records?.[0];
+        const rawKey = record?.s3?.object?.key;
+        if (!rawKey) {
+          return new Response('Bad S3 event', { status: 400 });
+        }
+        // Spaces in object keys from Minio are encoded as +
+        const decodedKey = decodeURIComponent(rawKey.replace(/\+/g, ' '));
+        const isDelete = record?.eventName?.startsWith('s3:ObjectRemoved');
+        await env.FILE_PROCESSOR_QUEUE.send({
+          ...(isDelete ? { action: 'DeleteObject' } : {}),
+          object: { key: decodedKey },
+        });
+        return new Response('Queued', { status: 200 });
+      }
+
+      // Health check
+      if (url.pathname === '/health') {
+        return new Response('OK', { status: 200 });
+      }
+      return new Response('Not Found', { status: 404 });
+    } catch (err) {
+      await captureError(env, {
+        source: 'worker_fetch',
+        method: request.method,
+        path: url.pathname,
+        error_message: err?.message,
+        error_name: err?.name,
+        error_stack: err?.stack,
       });
-
-      return Response.json({ instanceId: instance.id }, { status: 202 });
+      throw err;
     }
-
-    // Dev adapter for S3 events from Minio
-    if (env.ENVIRONMENT === 'dev' && url.pathname === '/queue') {
-      let event;
-      try {
-        event = await request.json();
-      } catch {
-        return new Response('Invalid JSON', { status: 400 });
-      }
-      const record = event.Records?.[0];
-      const rawKey = record?.s3?.object?.key;
-      if (!rawKey) {
-        return new Response('Bad S3 event', { status: 400 });
-      }
-      // Spaces in object keys from Minio are encoded as +
-      const decodedKey = decodeURIComponent(rawKey.replace(/\+/g, ' '));
-      const isDelete = record?.eventName?.startsWith('s3:ObjectRemoved');
-      await env.FILE_PROCESSOR_QUEUE.send({
-        ...(isDelete ? { action: 'DeleteObject' } : {}),
-        object: { key: decodedKey },
-      });
-      return new Response('Queued', { status: 200 });
-    }
-
-    // Health check
-    if (url.pathname === '/health') {
-      return new Response('OK', { status: 200 });
-    }
-    return new Response('Not Found', { status: 404 });
   },
 
   // Cron triggers
   async scheduled(controller, env, _ctx) {
-    validateEnv(env);
-    if (controller.cron === '0 3 * * *') {
-      const sql = getPostgresClient(env);
-      try {
-        const storage = getStorageClient(env);
-        const typesense = getTypesenseClient(env);
-        await cleanupExpiredSites({ sql, storage, typesense });
-      } finally {
-        await sql.end();
+    try {
+      validateEnv(env);
+      if (controller.cron === '0 3 * * *') {
+        const sql = getPostgresClient(env);
+        try {
+          const storage = getStorageClient(env);
+          const typesense = getTypesenseClient(env);
+          await cleanupExpiredSites({ sql, storage, typesense });
+        } finally {
+          await sql.end();
+        }
       }
+    } catch (err) {
+      await captureError(env, {
+        source: 'worker_scheduled',
+        cron: controller.cron,
+        error_message: err?.message,
+        error_name: err?.name,
+        error_stack: err?.stack,
+      });
+      throw err;
     }
   },
 
   // Queue consumer entry point
   async queue(batch, env, _ctx) {
-    validateEnv(env);
-    const storage = getStorageClient(env);
-    const sql = getPostgresClient(env);
-    const typesense = getTypesenseClient(env);
+    try {
+      validateEnv(env);
+      const storage = getStorageClient(env);
+      const sql = getPostgresClient(env);
+      const typesense = getTypesenseClient(env);
 
-    // Process all messages in parallel
-    await Promise.all(
-      batch.messages.map((msg) =>
-        handleMessage({ msg, storage, sql, typesense, env }),
-      ),
-    );
+      // Process all messages in parallel
+      await Promise.all(
+        batch.messages.map((msg) =>
+          handleMessage({ msg, storage, sql, typesense, env }),
+        ),
+      );
+    } catch (err) {
+      await captureError(env, {
+        source: 'worker_queue',
+        queue: batch.queue,
+        error_message: err?.message,
+        error_name: err?.name,
+        error_stack: err?.stack,
+      });
+      throw err;
+    }
   },
 };
 


### PR DESCRIPTION
Closes #1313

## What

Wraps each worker runtime entrypoint and both Cloudflare Workflows in a `try/catch` that reports uncaught errors to PostHog as a `$exception`, then re-throws.

Boundaries (each with a distinct `source` tag):

| Boundary | `source` |
|---|---|
| worker `fetch` | `worker_fetch` (+ `method`, `path`) |
| worker `scheduled` | `worker_scheduled` (+ `cron`) |
| worker `queue` | `worker_queue` (+ `queue`) |
| `GitHubSyncWorkflow.run()` | `workflow_github_sync` (+ `siteId`, `publishId`) |
| `PublishFinalizerWorkflow.run()` | `workflow_publish_finalizer` (+ `siteId`, `publishId`) |

## Why

Per the #1092 post-mortem, the orchestration layer (worker entrypoints + both Workflows) emitted nothing to PostHog — only the file-processing queue consumer did. Runtime failures there (like the original bad-deploy incident) were invisible in product analytics. This closes that gap so all worker errors land uniformly in PostHog error tracking.

## How

- Plain inline `try/catch` at each entrypoint calling the existing `captureError` — no new abstraction.
- Same `$exception` shape already used by the queue consumer (`distinct_id: 'system'`, `source`/`error_message`/`error_name`, plus `error_stack`).
- **Re-throws** after capture, so HTTP responses and Cloudflare Workflow retry/failure semantics are identical to before.
- Best-effort/non-blocking: inherits `captureError`'s POSTHOG_KEY no-op + swallowed transport failures.
- Queue consumer's existing per-file capture is untouched.

## Out of scope

Alerting/notifications, a stuck-publish detector, Next.js app changes, and OTel from the worker — this PR only ensures errors are *captured*.

## Notes

- Most of the line count in the two workflow files is re-indentation from wrapping `run()` bodies in `try` — the logic is unchanged.
- Full worker unit suite passes (68 tests); Biome lint clean.
