### PR TITLE
fix(cloudflare-worker): apply contentExclude/Include relative to rootDir (#1331)

### DIFF
--- a/apps/cloudflare-worker/src/github-sync-workflow.js
+++ b/apps/cloudflare-worker/src/github-sync-workflow.js
@@ -273,7 +273,14 @@ export function computeFilesToUpsert(
       (item) =>
         item.type !== 'tree' &&
         item.path.startsWith(normalizedRootDir) &&
-        isPathVisible(item.path, includes, excludes),
+        // Match include/exclude patterns against the site-relative path (rootDir
+        // stripped) — users write patterns relative to their site root ("/notes"),
+        // not the repo root ("<rootDir>/notes").
+        isPathVisible(
+          item.path.replace(normalizedRootDir, ''),
+          includes,
+          excludes,
+        ),
     )
     .map((item) => {
       const filePath = item.path.replace(normalizedRootDir, '');
@@ -307,7 +314,12 @@ export function computeFilesToDelete(
         (item) =>
           item.type !== 'tree' &&
           item.path.startsWith(normalizedRootDir) &&
-          isPathVisible(item.path, includes, excludes),
+          // See computeFilesToUpsert: match patterns against the site-relative path.
+          isPathVisible(
+            item.path.replace(normalizedRootDir, ''),
+            includes,
+            excludes,
+          ),
       )
       .map((item) => item.path.replace(normalizedRootDir, '')),
   );

--- a/apps/cloudflare-worker/test/unit/github-sync-workflow.test.js
+++ b/apps/cloudflare-worker/test/unit/github-sync-workflow.test.js
@@ -106,6 +106,37 @@ describe('computeFilesToUpsert', () => {
     expect(result[0].filePath).toBe('public/page.md');
   });
 
+  it('excludes files matching excludes when a rootDir is set (#1331)', () => {
+    // Exclude patterns are site-relative ("/notes"); the GitHub tree paths carry
+    // the rootDir prefix ("site/notes/..."). The exclude must still match after
+    // the prefix is stripped.
+    const result = computeFilesToUpsert(
+      [],
+      makeTree([
+        makeItem('site/notes/private.md', 'sha1'),
+        makeItem('site/docs/page.md', 'sha2'),
+      ]),
+      'site/',
+      [],
+      ['/notes'],
+    );
+    expect(result.map((r) => r.filePath)).toEqual(['docs/page.md']);
+  });
+
+  it('applies includes relative to rootDir (#1331)', () => {
+    const result = computeFilesToUpsert(
+      [],
+      makeTree([
+        makeItem('site/docs/page.md', 'sha1'),
+        makeItem('site/notes/page.md', 'sha2'),
+      ]),
+      'site/',
+      ['/docs'],
+      [],
+    );
+    expect(result.map((r) => r.filePath)).toEqual(['docs/page.md']);
+  });
+
   it('includes only files matching includes when includes is non-empty', () => {
     const result = computeFilesToUpsert(
       [],
@@ -231,5 +262,21 @@ describe('computeFilesToDelete', () => {
       [],
     );
     expect(result).toHaveLength(0);
+  });
+
+  it('deletes now-excluded blobs when a rootDir is set (#1331)', () => {
+    // A previously-synced blob whose path is now covered by contentExclude must
+    // be marked for deletion even though the tree path carries the rootDir prefix.
+    const result = computeFilesToDelete(
+      [{ path: 'notes/private.md' }, { path: 'docs/page.md' }],
+      makeTree([
+        makeItem('site/notes/private.md', 'sha1'),
+        makeItem('site/docs/page.md', 'sha2'),
+      ]),
+      'site/',
+      [],
+      ['/notes'],
+    );
+    expect(result.map((b) => b.path)).toEqual(['notes/private.md']);
   });
 });


### PR DESCRIPTION
Fixes #1331

## Problem

`contentExclude` (and `contentInclude`) have no effect for any site published from a subdirectory (`rootDir` set): excluded paths are still synced, served by URL, and listed in the sitemap.

## Root cause

Exclude/include are enforced at GitHub-sync time in `computeFilesToUpsert` / `computeFilesToDelete` (`apps/cloudflare-worker/src/github-sync-workflow.js`). Excluded files are meant to never reach storage, so there is (by design) no runtime filter downstream.

`isPathVisible` was called with the **raw GitHub tree path**, which still carries the `rootDir` prefix:

```js
isPathVisible(item.path, includes, excludes) // "<rootDir>/notes/page.md"
```

Users write patterns relative to their **site root** (`/notes`), so the prefix match never fired:

```js
"/<rootDir>/notes/page.md".startsWith("/notes/") // false ❌
"/notes/page.md".startsWith("/notes/")           // true  ✅
```

Sites published from the repo root (`rootDir=""`) were unaffected — which is why the existing unit tests, all using `rootDir=''`, passed.

## Fix

Strip `normalizedRootDir` before the visibility check in both `computeFilesToUpsert` and `computeFilesToDelete`, mirroring how `filePath` is already derived.

## Note on rollout

This stops *new* excluded files from being synced. Already-synced excluded blobs are cleared on the next **re-publish** — `computeFilesToDelete` now flags them for deletion.

## Tests

Added rootDir-aware regression tests for exclude, include, and delete (all prior tests only exercised `rootDir=''`). Full suite: 22/22 passing.
