### PR TITLE
feat(seo): unify site brand as siteName, deprecate config title

### DIFF
--- a/apps/flowershow/app/(cloud)/dashboard/site/[id]/settings/layout.tsx
+++ b/apps/flowershow/app/(cloud)/dashboard/site/[id]/settings/layout.tsx
@@ -41,18 +41,10 @@ export default async function SiteSettingsLayout(props: {
       <div className="mb-4 mt-6 flex items-start gap-2 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
         <InfoIcon className="mt-0.5 h-4 w-4 shrink-0 text-blue-500" />
         <span>
-          These dashboard settings control how your site looks and behaves. If
-          your site also uses{' '}
-          <code className="rounded bg-blue-100 px-1 py-0.5 font-mono text-xs">
-            config.json
-          </code>
-          , matching values from that file will override the dashboard settings
-          and may not appear here. To control a setting from the dashboard,
-          remove that setting from{' '}
-          <code className="rounded bg-blue-100 px-1 py-0.5 font-mono text-xs">
-            config.json
-          </code>{' '}
-          first.
+          Heads up: the separate <strong>Site Title</strong> setting has been
+          removed. Your site&apos;s name — appended as a suffix to every page
+          title and shown in your navbar and footer — now comes from the{' '}
+          <strong>Name</strong> field below.
         </span>
       </div>
       {children}

--- a/apps/flowershow/app/(cloud)/dashboard/site/[id]/settings/page.tsx
+++ b/apps/flowershow/app/(cloud)/dashboard/site/[id]/settings/page.tsx
@@ -263,7 +263,7 @@ export default async function SiteSettingsPage(props: {
           </div>
           <Form
             title="Name"
-            description="The name of your site. Only visible by you."
+            description="The name of your site. Shown in the navbar and footer, and appended as a suffix to every page title (browser tabs, search results, social shares, and bookmarks)."
             inputAttrs={{
               name: 'projectName',
               type: 'text',
@@ -274,14 +274,11 @@ export default async function SiteSettingsPage(props: {
               pattern: '^(?=.*[a-zA-Z0-9])[^/]+$',
             }}
             handleSubmit={renameSite}
-            helpText={`It must contain at least one letter or number and cannot contain "/". Renaming does not change your site's URL. Maximum ${SITE_NAME_MAX_LENGTH} characters.`}
-          />
-          <Form
-            title="Site Title"
-            description="Your site name, appended as a suffix to every page title. Appears in browser tabs, search results, social shares, and bookmarks."
             helpText={
               <>
-                Max 40 characters.{' '}
+                It must contain at least one letter or number and cannot contain
+                &quot;/&quot;. Renaming does not change your site&apos;s URL.
+                Maximum {SITE_NAME_MAX_LENGTH} characters.{' '}
                 <a
                   className="underline"
                   href="https://flowershow.app/docs/reference/seo-social-metadata"
@@ -291,14 +288,6 @@ export default async function SiteSettingsPage(props: {
                 </a>
               </>
             }
-            inputAttrs={{
-              name: 'title',
-              type: 'text',
-              defaultValue: siteConfig?.title ?? '',
-              placeholder: 'My Awesome Site',
-              maxLength: 40,
-            }}
-            handleSubmit={updateDbConfig}
           />
           <Form
             title="Description"

--- a/apps/flowershow/app/(public)/site/[user]/[project]/[[...slug]]/page.tsx
+++ b/apps/flowershow/app/(public)/site/[user]/[project]/[[...slug]]/page.tsx
@@ -29,6 +29,7 @@ import {
 import { preprocessMdxForgiving } from '@/lib/preprocess-mdx';
 import { processCanvas } from '@/lib/process-canvas';
 import { resolveSiteAlias } from '@/lib/resolve-site-alias';
+import { buildPageTitle, resolveSiteName } from '@/lib/site-config';
 import { ensureLeadingSlash } from '@/lib/utils';
 import type { PageMetadata } from '@/server/api/types';
 import { api } from '@/trpc/server';
@@ -86,10 +87,8 @@ export async function generateMetadata(props: {
     })
     .catch(() => null);
 
-  const title =
-    siteConfig?.title && metadata?.title
-      ? `${metadata?.title} - ${siteConfig.title}`
-      : (metadata?.title ?? siteConfig?.title ?? projectName);
+  const siteName = resolveSiteName(siteConfig, site.projectName);
+  const title = buildPageTitle(metadata?.title, siteName);
   const description = metadata?.description ?? siteConfig?.description;
   const url = decodedSlug !== '/' ? `${siteUrl}${decodedSlug}` : `${siteUrl}/`;
 

--- a/apps/flowershow/app/(public)/site/[user]/[project]/layout.tsx
+++ b/apps/flowershow/app/(public)/site/[user]/[project]/layout.tsx
@@ -14,6 +14,7 @@ import { env } from '@/env.mjs';
 import { getConfig } from '@/lib/app-config';
 import { Feature, isFeatureEnabled } from '@/lib/feature-flags';
 import { getThemeUrl } from '@/lib/get-theme';
+import { resolveSiteName } from '@/lib/site-config';
 import { fontBody, fontBrand, fontHeading } from '@/styles/fonts-public';
 import { TRPCReactProvider } from '@/trpc/react';
 import { api } from '@/trpc/server';
@@ -143,9 +144,10 @@ export default async function PublicLayout(props: {
     }
   }
 
-  // TODO: nav.logo is deprecated in favour of root logo — remove nav.logo fallback once migration period ends
-  const logo = siteConfig?.logo ?? siteConfig?.nav?.logo ?? appConfig.logo;
-  const title = siteConfig?.nav?.title;
+  const userLogo = siteConfig?.logo ?? siteConfig?.nav?.logo;
+  const logo = userLogo ?? appConfig.logo;
+  const siteName = resolveSiteName(siteConfig, site.projectName);
+  const navTitle = siteConfig?.nav?.title ?? (userLogo ? undefined : siteName);
   const links = siteConfig?.nav?.links;
   const social = siteConfig?.social || siteConfig?.nav?.social;
   const canHideBuiltWith = isFeatureEnabled(Feature.NoBranding, site);
@@ -250,7 +252,7 @@ export default async function PublicLayout(props: {
                   <Nav
                     logo={logo}
                     url={sitePrefix || '/'}
-                    title={title}
+                    title={navTitle}
                     links={links}
                     social={social}
                     showSearch={showSearch}
@@ -261,7 +263,7 @@ export default async function PublicLayout(props: {
                 )}
                 <div className="site-body">{children}</div>
                 <Footer
-                  siteName={siteConfig?.title || site.projectName}
+                  siteName={siteName}
                   social={social}
                   navigation={siteConfig?.footer?.navigation}
                 />

--- a/apps/flowershow/app/api/rss/[user]/[project]/route.test.ts
+++ b/apps/flowershow/app/api/rss/[user]/[project]/route.test.ts
@@ -19,6 +19,9 @@ vi.mock('@/lib/site-config', () => ({
   resolveSiteConfig: vi
     .fn()
     .mockReturnValue({ enableRss: true, title: 't', description: 'd' }),
+  resolveSiteName: vi.fn(
+    (config, projectName) => config?.siteName ?? config?.title ?? projectName,
+  ),
 }));
 
 vi.mock('@/lib/get-site-url', () => ({

--- a/apps/flowershow/app/api/rss/[user]/[project]/route.ts
+++ b/apps/flowershow/app/api/rss/[user]/[project]/route.ts
@@ -5,7 +5,7 @@ import { fetchFile } from '@/lib/content-store';
 import { getSiteUrl } from '@/lib/get-site-url';
 import { buildRssFeed } from '@/lib/rss';
 import { hasSiteAccess } from '@/lib/site-access';
-import { resolveSiteConfig } from '@/lib/site-config';
+import { resolveSiteConfig, resolveSiteName } from '@/lib/site-config';
 import prisma from '@/server/db';
 import { Prisma } from '@prisma/client';
 
@@ -83,9 +83,8 @@ export async function GET(
   }
 
   const siteUrl = getSiteUrl(site);
-  const siteTitle = siteConfig.title ?? site.projectName;
-  const siteDescription =
-    siteConfig.description ?? `${site.projectName} RSS Feed`;
+  const siteTitle = resolveSiteName(siteConfig, site.projectName);
+  const siteDescription = siteConfig.description ?? `${siteTitle} RSS Feed`;
 
   const xml = buildRssFeed(
     { siteUrl, title: siteTitle, description: siteDescription },

--- a/apps/flowershow/components/types.ts
+++ b/apps/flowershow/components/types.ts
@@ -62,6 +62,9 @@ export interface FooterConfig {
 }
 
 export interface SiteConfig {
+  /** The site's brand/name — used as the SEO title suffix, navbar name (when not overridden by nav.title), footer publication name, and RSS channel title. */
+  siteName?: string;
+  /** @deprecated Use `siteName` instead. Still honored as a fallback for existing configs. */
   title?: string;
   description?: string;
   image?: string;

--- a/apps/flowershow/lib/site-config.test.ts
+++ b/apps/flowershow/lib/site-config.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { resolveSiteConfig } from './site-config';
+import {
+  buildPageTitle,
+  resolveSiteConfig,
+  resolveSiteName,
+} from './site-config';
 
 describe('resolveSiteConfig', () => {
   it('returns empty object when all inputs are null', () => {
@@ -67,5 +71,40 @@ describe('resolveSiteConfig', () => {
     const file = { theme: 'forest' };
     const result = resolveSiteConfig(db, file);
     expect(result.theme).toBe('forest');
+  });
+});
+
+describe('resolveSiteName', () => {
+  it('prefers siteName over the deprecated title and the project name', () => {
+    expect(
+      resolveSiteName({ siteName: 'Brand', title: 'Old' }, 'my-project'),
+    ).toBe('Brand');
+  });
+
+  it('falls back to the deprecated title when siteName is unset', () => {
+    expect(resolveSiteName({ title: 'Old Brand' }, 'my-project')).toBe(
+      'Old Brand',
+    );
+  });
+
+  it('falls back to the project name when neither is set', () => {
+    expect(resolveSiteName({}, 'my-project')).toBe('my-project');
+    expect(resolveSiteName(null, 'my-project')).toBe('my-project');
+  });
+});
+
+describe('buildPageTitle', () => {
+  it('appends the brand as a suffix to the page title', () => {
+    expect(buildPageTitle('About', 'My Site')).toBe('About - My Site');
+  });
+
+  it('returns the brand alone when the page has no title', () => {
+    expect(buildPageTitle(undefined, 'My Site')).toBe('My Site');
+    expect(buildPageTitle('', 'My Site')).toBe('My Site');
+  });
+
+  it('deduplicates when the page title equals the brand (case-insensitive)', () => {
+    expect(buildPageTitle('My Site', 'My Site')).toBe('My Site');
+    expect(buildPageTitle('  my site ', 'My Site')).toBe('My Site');
   });
 });

--- a/apps/flowershow/lib/site-config.ts
+++ b/apps/flowershow/lib/site-config.ts
@@ -71,3 +71,28 @@ export function resolveSiteConfig(
   }
   return resolved;
 }
+
+/**
+ * Resolves the site's brand/name — the single value shown as the SEO title
+ * suffix, navbar name, footer publication name, and RSS channel title.
+ */
+export function resolveSiteName(
+  siteConfig: SiteConfig | null | undefined,
+  projectName: string,
+): string {
+  return siteConfig?.siteName ?? siteConfig?.title ?? projectName;
+}
+
+/**
+ * Builds a page's `<title>` from the page title and the resolved brand.
+ */
+export function buildPageTitle(
+  pageTitle: string | null | undefined,
+  siteName: string,
+): string {
+  if (!pageTitle) return siteName;
+  if (pageTitle.trim().toLowerCase() === siteName.trim().toLowerCase()) {
+    return siteName;
+  }
+  return `${pageTitle} - ${siteName}`;
+}

--- a/apps/flowershow/prisma/migrations/20260731120000_migrate_dashboard_title_to_project_name/migration.sql
+++ b/apps/flowershow/prisma/migrations/20260731120000_migrate_dashboard_title_to_project_name/migration.sql
@@ -1,0 +1,93 @@
+-- Migrate dashboard-set `config_json.title` into `project_name`.
+--
+-- The site brand (SEO title suffix, navbar, footer, RSS) now resolves to
+-- siteName ?? title(deprecated) ?? projectName, and the dashboard "Site Title"
+-- field has been removed. Sites that set a title via the dashboard have it in
+-- config_json.title, where it still applies (via the read-time alias) but is no
+-- longer visible/editable and silently overrides the dashboard "Name" field.
+-- This migration makes project_name the single source of truth: set project_name
+-- to the title and drop the title key. The public URL derives from
+-- subdomain/custom_domain (never project_name), so this does not change any
+-- site's URL -- it is equivalent to a bulk rename.
+--
+-- A site is left UNTOUCHED (its title kept, so the alias keeps applying it) when
+-- the title cannot become a valid, unique project_name:
+--   - fails Site Name validation: empty, no ASCII alphanumeric, contains "/", or
+--     has control characters (dashboard titles were only length-capped, so these
+--     are possible), or longer than 100 chars
+--   - would collide with another of the same user's sites (unique[user, name]),
+--     including the case where two of a user's sites resolve to the same name
+-- Whitespace is trimmed to match the app's validateSiteName().
+--
+-- PRE-FLIGHT preview (safe, read-only): run this first to see what will happen
+-- to every site that has a dashboard title -- rename / clean / SKIP:
+--
+--   WITH norm AS (
+--     SELECT id, user_id, project_name,
+--            regexp_replace(config_json->>'title', '^\s+|\s+$', '', 'g') AS new_name
+--     FROM "Site" WHERE jsonb_typeof(config_json->'title') = 'string'
+--   )
+--   SELECT n.project_name AS old_name, n.new_name,
+--     CASE
+--       WHEN n.new_name = n.project_name THEN 'clean (remove key)'
+--       WHEN char_length(n.new_name) NOT BETWEEN 1 AND 100
+--            OR n.new_name !~ '[A-Za-z0-9]'
+--            OR n.new_name LIKE '%/%'
+--            OR n.new_name ~ '[[:cntrl:]]' THEN 'SKIP invalid'
+--       WHEN EXISTS (SELECT 1 FROM "Site" o
+--                    WHERE o.user_id = n.user_id AND o.project_name = n.new_name AND o.id <> n.id)
+--            OR (SELECT count(*) FROM norm m WHERE m.user_id = n.user_id AND m.new_name = n.new_name) > 1
+--            THEN 'SKIP collision'
+--       ELSE 'rename'
+--     END AS action
+--   FROM norm n ORDER BY action, old_name;
+
+-- 1) Title already equals project_name: just drop the redundant key.
+UPDATE "Site"
+SET config_json = config_json - 'title'
+WHERE jsonb_typeof(config_json->'title') = 'string'
+  AND regexp_replace(config_json->>'title', '^\s+|\s+$', '', 'g') = project_name;
+
+-- 2) Valid + unique title: set project_name and drop the key.
+WITH norm AS (
+  SELECT
+    id,
+    user_id,
+    project_name,
+    regexp_replace(config_json->>'title', '^\s+|\s+$', '', 'g') AS new_name
+  FROM "Site"
+  WHERE jsonb_typeof(config_json->'title') = 'string'
+),
+cand AS (
+  SELECT id, user_id, new_name
+  FROM norm
+  WHERE new_name <> project_name
+    AND char_length(new_name) BETWEEN 1 AND 100
+    AND new_name ~ '[A-Za-z0-9]'          -- at least one ASCII alphanumeric
+    AND new_name NOT LIKE '%/%'           -- no "/"
+    AND new_name !~ '[[:cntrl:]]'         -- no control characters
+),
+-- Only names that are unique among this user's candidates (drops same-user dupes).
+uniq_cand AS (
+  SELECT user_id, new_name
+  FROM cand
+  GROUP BY user_id, new_name
+  HAVING count(*) = 1
+),
+-- ...and that no other existing site of the same user already owns.
+eligible AS (
+  SELECT c.id, c.new_name
+  FROM cand c
+  JOIN uniq_cand u ON u.user_id = c.user_id AND u.new_name = c.new_name
+  WHERE NOT EXISTS (
+    SELECT 1 FROM "Site" o
+    WHERE o.user_id = c.user_id
+      AND o.project_name = c.new_name
+      AND o.id <> c.id
+  )
+)
+UPDATE "Site" s
+SET project_name = e.new_name,
+    config_json  = s.config_json - 'title'
+FROM eligible e
+WHERE s.id = e.id;

--- a/content/flowershow-app/config.json
+++ b/content/flowershow-app/config.json
@@ -1,5 +1,5 @@
 {
-  "title": "Flowershow — Publish Markdown as a Website",
+  "siteName": "Flowershow",
   "showSidebar": true,
   "sidebar": {
     "paths": [
@@ -8,7 +8,6 @@
     ]
   },
   "nav": {
-    "title": "Flowershow",
     "links": [
       {
         "name": "Use Cases",

--- a/content/flowershow-app/docs/reference/config-file.md
+++ b/content/flowershow-app/docs/reference/config-file.md
@@ -16,16 +16,19 @@ Place `config.json` in the root of your published content folder. For most users
 
 ## Options
 
-### `title`
+### `siteName`
 
 **Type:** `string`  
-**Default:** —
+**Default:** your project name
 
-Site name appended as a suffix to every page title in browser tabs, search results, and social shares. [[seo-social-metadata|Learn more →]]
+Your site's name — appended as a suffix to every page title (browser tabs, search results, social shares) and shown in the navbar and footer. Overrides the name set in the dashboard under **Settings → General → Name**. [[seo-social-metadata|Learn more →]]
 
 ```json
-"title": "My Digital Garden"
+"siteName": "My Digital Garden"
 ```
+
+> [!note]
+> `title` is still accepted as a deprecated alias for `siteName`. Existing configs keep working, but new sites should use `siteName`.
 
 ---
 

--- a/content/flowershow-app/docs/reference/footer.md
+++ b/content/flowershow-app/docs/reference/footer.md
@@ -6,7 +6,7 @@ description: Customize your site footer with navigation links and social media i
 Configure your site footer from the **Flowershow dashboard** under **Site Settings → Navigation**, or using `config.json` if you prefer to version-control your settings or manage them via an automated workflow.
 
 > [!note]
-> The footer automatically displays your site name and a copyright notice. If no title is configured, it falls back to your project name. The year updates automatically.
+> The footer automatically displays your site name and a copyright notice. The site name comes from **Settings → General → Name** (or `siteName` in `config.json`). The year updates automatically.
 
 ## Social media links
 
@@ -40,6 +40,7 @@ Go to **Settings → Navigation → Footer Navigation** and enter your navigatio
 ```
 
 Each group requires:
+
 - `title`: Heading for the group
 - `links`: Array of link objects, each with `name` (display text) and `href` (URL or path)
 
@@ -49,7 +50,7 @@ If you want to version-control your configuration, or have your editor's AI agen
 
 ```json
 {
-  "title": "My Digital Garden",
+  "siteName": "My Digital Garden",
   "social": [
     { "label": "github", "href": "https://github.com/yourusername" },
     { "label": "twitter", "href": "https://twitter.com/yourusername" },
@@ -78,7 +79,7 @@ If you want to version-control your configuration, or have your editor's AI agen
 }
 ```
 
-- `title`: Site name shown in the footer copyright — this is only configurable via `config.json`, not from the dashboard
+- `siteName`: Your site's name, shown in the footer copyright. Overrides the name set in the dashboard (**Settings → General → Name**); defaults to your project name. `title` is still accepted as a deprecated alias.
 - `social`: Array of social link objects (same format as the dashboard JSON editor) — see [[social-links]]
 - `footer.navigation`: Array of navigation group objects (same format as the dashboard JSON editor)
 

--- a/content/flowershow-app/docs/reference/navbar.md
+++ b/content/flowershow-app/docs/reference/navbar.md
@@ -13,7 +13,9 @@ Configure your site's navigation bar from the **Flowershow dashboard**, or using
 Go to **Settings → Navigation** and set:
 
 - **Logo** — upload an image file
-- **Nav Title** — the text shown as your site title in the navbar
+- **Nav Title** — the text shown next to the logo in the navbar
+
+If you don't set a nav title, your site name (from **Settings → General → Name**) is shown next to the logo by default — unless you've uploaded your own logo, in which case the logo stands alone. Set a nav title to override this with different text.
 
 > [!note]
 > To use a file path, external URL, or emoji as your logo, use `config.json` — the dashboard logo field accepts image uploads only.

--- a/content/flowershow-app/docs/reference/rss-feed.md
+++ b/content/flowershow-app/docs/reference/rss-feed.md
@@ -35,7 +35,7 @@ Pages without a `date` field (e.g. documentation pages, landing pages) are exclu
 
 ## Feed metadata
 
-The feed's title and description are taken from your site's title and description settings. If no title is configured, the feed title defaults to your site's project name.
+The feed's title and description are taken from your site's name and description settings. The feed title is your site name (**Settings → General → Name**, or `siteName` in `config.json`).
 
 ## Using config.json
 
@@ -44,20 +44,20 @@ If you want to version-control your configuration, or have your editor's AI agen
 ```json
 {
   "enableRss": true,
-  "title": "My Site",
+  "siteName": "My Site",
   "description": "A site about interesting things"
 }
 ```
 
 - `enableRss`: Set to `true` to enable the RSS feed
-- `title`: Feed title (falls back to your site's project name if not set)
+- `siteName`: Feed title — your site's name (defaults to your project name). `title` is still accepted as a deprecated alias.
 - `description`: Feed description
 
 ## Frontmatter fields used
 
-| Field | Required | Used for |
-|-------|----------|----------|
-| `date` | Yes | Determines inclusion in feed and the item's publication date |
-| `title` | No | Item title (falls back to file name) |
-| `description` | No | Item summary |
-| `authors` | No | Item author(s) |
+| Field         | Required | Used for                                                     |
+| ------------- | -------- | ------------------------------------------------------------ |
+| `date`        | Yes      | Determines inclusion in feed and the item's publication date |
+| `title`       | No       | Item title (falls back to file name)                         |
+| `description` | No       | Item summary                                                 |
+| `authors`     | No       | Item author(s)                                               |

--- a/content/flowershow-app/docs/reference/seo-social-metadata.md
+++ b/content/flowershow-app/docs/reference/seo-social-metadata.md
@@ -5,15 +5,17 @@ description: Configure SEO titles, descriptions, and social media images for bet
 
 Configure site-wide SEO defaults from the **Flowershow dashboard** under **Site Settings → General**, or using `config.json` if you prefer to version-control your settings or manage them via an automated workflow.
 
-## Site title
+## Site name
 
-Go to **Settings → General → Site Title** and enter your site name.
+Your site's name is set from **Settings → General → Name**.
 
-This value is appended as a suffix to every page title and appears in browser tabs, search results, social shares, and bookmarks. It doesn't affect how the title displays on the page itself. Keep the combined title under 60 characters for best results.
+This value is appended as a suffix to every page title and appears in browser tabs, search results, social shares, and bookmarks. It's also shown in your site's navbar and footer. It doesn't affect how the title displays in the page body itself. Keep the combined title under 60 characters for best results.
 
 **Page title:** "My Guide"  
-**Site title:** "My Site"  
+**Site name:** "My Site"  
 **Final SEO title:** "My Guide - My Site"
+
+When a page's title is the same as your site name — for example, your home page — the name isn't repeated. The SEO title is just "My Site" rather than "My Site - My Site".
 
 ## Default description
 
@@ -79,15 +81,18 @@ If you want to version-control your configuration, or have your editor's AI agen
 
 ```json
 {
-  "title": "My Site Name",
+  "siteName": "My Site Name",
   "description": "Default site description.",
   "image": "/assets/default-social.jpg"
 }
 ```
 
-- `title`: Site name appended as a suffix to every page title
+- `siteName`: Your site's name, appended as a suffix to every page title. Overrides the name set in the dashboard; defaults to your project name.
 - `description`: Fallback description for pages with no frontmatter description
 - `image`: Path to the default social image (relative to site root) or an external URL
+
+> [!note]
+> `title` is still accepted as a deprecated alias for `siteName`. Existing configs keep working, but new sites should use `siteName`.
 
 ### Complete example
 
@@ -105,7 +110,7 @@ image: /assets/docker-guide-social.jpg
 
 ```json
 {
-  "title": "DevTutorials",
+  "siteName": "DevTutorials",
   "description": "Professional development tutorials for modern developers.",
   "image": "/assets/devtutorials-default.jpg"
 }


### PR DESCRIPTION
## What

There is now **one concept — your site's name** — and it consistently drives everywhere a site name appears: the SEO `<title>` / OG / Twitter suffix, the navbar, the footer, and the RSS channel title.

Your site name is set in the dashboard (**Settings → General → Name**) and stored on the site record. `config.json` can override it with `siteName` for version-controlled / config-as-code setups. The old `title` key is **deprecated but still works as an alias** for `siteName`.

Resolution (override → default):

```
config.json siteName  →  config.json title (deprecated alias)  →  your site's name
```

> Note: `projectName` is **not** a separate value or an extra fallback — it's just the current name of the DB column that stores your site's name.

## Why

`title` was doing two unrelated jobs and doing the main one poorly:

- As the **SEO suffix**, it only applied if a user had explicitly set it — so most sites got **no** brand suffix at all.
- The dashboard had **two** name fields — the site **Name** and a separate **Site Title** — and the latter silently overrode the former via the config.

This collapses it into a single, well-defined site name.

## Changes

- **One resolver** — `resolveSiteName` + `buildPageTitle` (`lib/site-config.ts`), used by the page metadata, navbar, footer, and RSS so they can't drift.
- **Dedup** — case-insensitive: a page whose title equals the site name renders just `Name` instead of `Name - Name` (e.g. home pages).
- **Branded by default** — because the site name is always present, every page now gets a suffix out of the box (previously only if `title` was set).
- **Config** — `SiteConfig.siteName` added; `title` marked `@deprecated` and kept as a read-time alias, so existing `config.json` and dashboard configs keep working unchanged.
- **Navbar** — shows the site name by default, **logo-gated** (sites with their own logo are unaffected); `nav.title` remains an explicit override.
- **Dashboard** — removed the redundant **Site Title** field; the **Name** field already *is* your site's name. Added a settings-page notice explaining the change.
- **Migration** (`20260731120000_migrate_dashboard_title_to_project_name`) — copies any dashboard-set `config_json.title` into the site's name column and drops the deprecated key. Skips values that can't be a valid/unique name. The public URL is derived from subdomain/custom domain, so **no URL changes**.
- **Docs** — seo-social-metadata, config-file, navbar, footer, rss updated; the Flowershow site config now uses `siteName`.

## Migration — run before/with deploy

Applied on `prisma migrate deploy`. **Run the pre-flight `SELECT`** (commented at the top of `migration.sql`) against production first to confirm the affected rows and see whether any fall into the skip cases.

## Testing

- `tsc --noEmit`: clean
- ESLint: clean
- Unit tests: passing (incl. new cases for `resolveSiteName` / `buildPageTitle` and dedup)
