### PR TITLE
fix(flowershow): prevent RangeError crash from unparseable frontmatter dates

### DIFF
--- a/apps/cloudflare-worker/src/queue-consumer.js
+++ b/apps/cloudflare-worker/src/queue-consumer.js
@@ -451,6 +451,17 @@ async function syncLinks(sql, siteId, blobId, markdown) {
   }
 }
 
+/**
+ * Convert a user-controlled frontmatter `date` into a Unix timestamp (seconds),
+ * or null when it isn't a parseable date. Frontmatter dates are often ranges
+ * ("1964-1982") or free text, which would otherwise index as NaN.
+ */
+function getUnixTimestamp(value) {
+  if (value == null || value === '') return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.getTime() / 1000;
+}
+
 async function indexInTypesense({
   typesense,
   siteId,
@@ -467,7 +478,7 @@ async function indexInTypesense({
       path,
       description: metadata.description,
       authors: metadata.authors,
-      date: metadata.date ? new Date(metadata.date).getTime() / 1000 : null,
+      date: getUnixTimestamp(metadata.date),
       id: `${blobId}`,
     };
     await typesense.collections(siteId).documents().upsert(document);

--- a/apps/flowershow/components/public/layouts/blog.tsx
+++ b/apps/flowershow/components/public/layouts/blog.tsx
@@ -2,6 +2,8 @@ import { CalendarIcon } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 
+import { safeDate } from '@/lib/utils';
+
 interface Props extends React.PropsWithChildren {
   title: string;
   description?: string;
@@ -23,7 +25,7 @@ export const BlogLayout: React.FC<Props> = ({
   date,
   authors,
 }) => {
-  const formattedDate = date ? formatDate(date) : null;
+  const parsedDate = safeDate(date);
 
   return (
     <>
@@ -87,12 +89,18 @@ export const BlogLayout: React.FC<Props> = ({
               </div>
             )}
 
-            {date && formattedDate && (
+            {date && (
               <div className="page-header-date">
                 <CalendarIcon className="page-header-date-icon" />
-                <time dateTime={new Date(date).toISOString()}>
-                  {formattedDate}
-                </time>
+                {parsedDate ? (
+                  <time dateTime={parsedDate.toISOString()}>
+                    {formatDate(parsedDate)}
+                  </time>
+                ) : (
+                  // Not a parseable date (e.g. a range like "1964-1982"); render
+                  // the raw frontmatter value rather than crashing the render.
+                  <span>{date}</span>
+                )}
               </div>
             )}
           </div>
@@ -103,17 +111,12 @@ export const BlogLayout: React.FC<Props> = ({
   );
 };
 
-const formatDate = (
-  date: string | undefined,
-  locales = 'en-US',
-): string | null => {
-  if (!date) return null;
-
+const formatDate = (date: Date, locales = 'en-US'): string => {
   const options: Intl.DateTimeFormatOptions = {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
   };
 
-  return new Date(date).toLocaleDateString(locales, options);
+  return date.toLocaleDateString(locales, options);
 };

--- a/apps/flowershow/lib/rss.ts
+++ b/apps/flowershow/lib/rss.ts
@@ -1,3 +1,5 @@
+import { safeDate } from './utils';
+
 export interface RssBlob {
   appPath: string | null;
   updatedAt: Date;
@@ -37,9 +39,7 @@ export function buildRssItem(blob: RssBlob, siteUrl: string): string {
   const description = metadata.description
     ? escapeXml(metadata.description as string)
     : '';
-  const pubDate = metadata.date
-    ? new Date(metadata.date as string).toUTCString()
-    : blob.updatedAt.toUTCString();
+  const pubDate = (safeDate(metadata.date) ?? blob.updatedAt).toUTCString();
   const authors = metadata.authors as string[] | undefined;
   const author = authors?.length ? escapeXml(authors.join(', ')) : '';
 
@@ -59,8 +59,8 @@ export function buildRssFeed(
 ): string {
   const filtered = filterRssBlobs(blobs)
     .sort((a, b) => {
-      const dateA = new Date(a.metadata?.date as string).getTime();
-      const dateB = new Date(b.metadata?.date as string).getTime();
+      const dateA = safeDate(a.metadata?.date)?.getTime() ?? 0;
+      const dateB = safeDate(b.metadata?.date)?.getTime() ?? 0;
       return dateB - dateA;
     })
     .slice(0, maxItems);

--- a/apps/flowershow/lib/utils.test.ts
+++ b/apps/flowershow/lib/utils.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { safeDate } from './utils';
+
+describe('safeDate', () => {
+  it('parses a valid ISO date string', () => {
+    const result = safeDate('2024-01-15');
+    expect(result).toBeInstanceOf(Date);
+    expect(result?.toISOString()).toBe('2024-01-15T00:00:00.000Z');
+  });
+
+  it('parses a Date instance', () => {
+    const input = new Date('2024-01-15T00:00:00.000Z');
+    expect(safeDate(input)?.getTime()).toBe(input.getTime());
+  });
+
+  it('returns null for a Zotero-style date range', () => {
+    // Regression: "1964-1982" previously threw RangeError via .toISOString()
+    expect(safeDate('1964-1982')).toBeNull();
+  });
+
+  it('returns null for free-text dates', () => {
+    expect(safeDate('forthcoming')).toBeNull();
+    expect(safeDate('date')).toBeNull();
+  });
+
+  it('returns null for null, undefined, and empty string', () => {
+    expect(safeDate(null)).toBeNull();
+    expect(safeDate(undefined)).toBeNull();
+    expect(safeDate('')).toBeNull();
+  });
+
+  it('does not throw for any input', () => {
+    expect(() => safeDate({})).not.toThrow();
+    expect(() => safeDate([])).not.toThrow();
+    expect(safeDate({})).toBeNull();
+  });
+});

--- a/apps/flowershow/lib/utils.ts
+++ b/apps/flowershow/lib/utils.ts
@@ -52,6 +52,22 @@ export const toDateString = (date: Date) => {
   });
 };
 
+/**
+ * Parses a value into a valid Date, or returns null if it can't be parsed.
+ *
+ * Frontmatter `date` fields are user-controlled and frequently hold values that
+ * are not parseable dates — e.g. Zotero-style ranges ("1964-1982"), year-only
+ * values, template placeholders, or free text. Passing those straight to
+ * `new Date(...).toISOString()` / `.toUTCString()` throws
+ * `RangeError: Invalid time value` and crashes the render. Use this at every
+ * boundary where a frontmatter date is turned into a Date.
+ */
+export function safeDate(value: unknown): Date | null {
+  if (value == null || value === '') return null;
+  const date = new Date(value as string | number | Date);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
 export const random = (min: number, max: number) => {
   return Math.floor(Math.random() * (max - min + 1) + min);
 };

--- a/apps/flowershow/scripts/reindex-site-typesense.ts
+++ b/apps/flowershow/scripts/reindex-site-typesense.ts
@@ -49,6 +49,8 @@ import { PrismaClient } from '@prisma/client';
 import matter from 'gray-matter';
 import { Client as TypesenseClient } from 'typesense';
 
+import { safeDate } from '../lib/utils';
+
 // ---------------------------------------------------------------------------
 // Configuration — read directly from process.env to avoid env.mjs full validation
 // ---------------------------------------------------------------------------
@@ -366,7 +368,9 @@ async function reindexSite(siteId: string, dryRun: boolean) {
         path: filePath,
         description: metadata.description,
         authors: metadata.authors,
-        date: metadata.date ? new Date(metadata.date).getTime() / 1000 : null,
+        date: safeDate(metadata.date)
+          ? safeDate(metadata.date)!.getTime() / 1000
+          : null,
       };
 
       if (dryRun) {


### PR DESCRIPTION
## Problem

User-controlled frontmatter `date` values that aren't parseable dates were passed straight to `.toISOString()` / `.toUTCString()`, which throws and **crashes the entire server render of the published page**. Confirmed reproducing pages are mostly Zotero-exported reference libraries (`date: 1964-1982` — a range) and template pages (`date` placeholder).

### Root cause

`components/public/layouts/blog.tsx` guarded only for missing dates. `formatDate` on an invalid date returns the truthy string `"Invalid Date"` (doesn't throw), so the guard passed — then `<time dateTime={new Date(date).toISOString()}>` threw.

## Fix

- **`lib/utils.ts`** — new `safeDate()` helper: parses to a `Date` or returns `null`, never throws.
- **`blog.tsx`** (crash site) — render `<time>` only for valid dates; invalid values render as plain text (so `1964-1982` still displays) instead of crashing.
- **`lib/rss.ts`** — `pubDate` falls back to `blob.updatedAt`; sort comparator no longer yields `NaN`.
- **`scripts/reindex-site-typesense.ts`** & **`apps/cloudflare-worker/src/queue-consumer.js`** — guard the Typesense `date` field (was silently indexing `NaN`).

## Testing

- Added `lib/utils.test.ts`, including the exact `1964-1982` regression case.
- `vitest --project=unit` (utils + rss): **33 passed**
- `tsc --noEmit`: **exit 0**
- `eslint`: **exit 0**

## Notes

No instrumentation change needed — `onRequestError` already attaches `request_path`, so future occurrences of this error class carry the URL.

Closes #1352 