### PR TITLE
fix(flowershow): coerce scalar frontmatter authors to prevent ZodError crash

### DIFF
--- a/apps/flowershow/app/(public)/site/[user]/[project]/[[...slug]]/page.tsx
+++ b/apps/flowershow/app/(public)/site/[user]/[project]/[[...slug]]/page.tsx
@@ -30,7 +30,7 @@ import { preprocessMdxForgiving } from '@/lib/preprocess-mdx';
 import { processCanvas } from '@/lib/process-canvas';
 import { resolveSiteAlias } from '@/lib/resolve-site-alias';
 import { buildPageTitle, resolveSiteName } from '@/lib/site-config';
-import { ensureLeadingSlash } from '@/lib/utils';
+import { ensureLeadingSlash, normalizeAuthors } from '@/lib/utils';
 import type { PageMetadata } from '@/server/api/types';
 import { api } from '@/trpc/server';
 import BacklinksPanel from './_components/backlinks-panel';
@@ -365,10 +365,14 @@ export default async function SitePage(props: {
     );
   }
 
-  const authors = metadata?.authors
+  // Frontmatter `authors` is user-controlled: it may be a scalar (`authors: Jane`)
+  // or arbitrary YAML, while getAuthors requires string[]. Normalize before the
+  // query so a scalar renders correctly and malformed values don't crash render.
+  const normalizedAuthors = normalizeAuthors(metadata?.authors);
+  const authors = normalizedAuthors.length
     ? await api.site.getAuthors.query({
         siteId: site.id,
-        authors: metadata.authors,
+        authors: normalizedAuthors,
       })
     : undefined;
 

--- a/apps/flowershow/lib/utils.test.ts
+++ b/apps/flowershow/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { safeDate } from './utils';
+import { normalizeAuthors, safeDate } from './utils';
 
 describe('safeDate', () => {
   it('parses a valid ISO date string', () => {
@@ -33,5 +33,40 @@ describe('safeDate', () => {
     expect(() => safeDate({})).not.toThrow();
     expect(() => safeDate([])).not.toThrow();
     expect(safeDate({})).toBeNull();
+  });
+});
+
+describe('normalizeAuthors', () => {
+  it('coerces a single scalar author to a one-item list', () => {
+    // Regression: `authors: Jane` previously threw a ZodError and crashed render
+    expect(normalizeAuthors('Jane')).toEqual(['Jane']);
+  });
+
+  it('passes through a list of author strings', () => {
+    expect(normalizeAuthors(['Jane', 'Bob'])).toEqual(['Jane', 'Bob']);
+  });
+
+  it('keeps wikilink-style entries intact', () => {
+    expect(normalizeAuthors('[[Jane Doe]]')).toEqual(['[[Jane Doe]]']);
+  });
+
+  it('drops empty, whitespace-only, and non-string entries', () => {
+    expect(normalizeAuthors(['Jane', '', '   ', null, 42, 'Bob'])).toEqual([
+      'Jane',
+      'Bob',
+    ]);
+  });
+
+  it('returns an empty list for null, undefined, and empty string', () => {
+    expect(normalizeAuthors(null)).toEqual([]);
+    expect(normalizeAuthors(undefined)).toEqual([]);
+    expect(normalizeAuthors('')).toEqual([]);
+    expect(normalizeAuthors('   ')).toEqual([]);
+  });
+
+  it('returns an empty list for malformed shapes without throwing', () => {
+    expect(() => normalizeAuthors({ foo: 'bar' })).not.toThrow();
+    expect(normalizeAuthors({ foo: 'bar' })).toEqual([]);
+    expect(normalizeAuthors(2023)).toEqual([]);
   });
 });

--- a/apps/flowershow/lib/utils.ts
+++ b/apps/flowershow/lib/utils.ts
@@ -68,6 +68,25 @@ export function safeDate(value: unknown): Date | null {
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
+/**
+ * Normalizes a user-controlled frontmatter `authors` value into a clean list of
+ * author strings.
+ *
+ * `authors` is documented as a list, but users naturally write a single scalar
+ * (`authors: Jane`) when there's one author, and YAML frontmatter can hold
+ * arbitrary shapes. The tRPC `getAuthors` input requires `string[]`, so a scalar
+ * (or any non-array) previously threw a ZodError and crashed the whole page
+ * render. Coerce a scalar to a single-item list, keep only non-empty string
+ * entries from a list, and drop anything else — never throw.
+ */
+export function normalizeAuthors(value: unknown): string[] {
+  const list = Array.isArray(value) ? value : [value];
+  return list.filter(
+    (entry): entry is string =>
+      typeof entry === 'string' && entry.trim().length > 0,
+  );
+}
+
 export const random = (min: number, max: number) => {
   return Math.floor(Math.random() * (max - min + 1) + min);
 };


### PR DESCRIPTION
## Problem

The `authors` frontmatter field is documented as a list, but users naturally write a single scalar when there's one author:

```yaml
---
title: My post
authors: Jane
---
```

The tRPC `getAuthors` input requires `authors: z.array(z.string())`, so a scalar (or any non-array YAML shape) throws a **ZodError** — which crashes the server render of the **entire published page**, not just the author byline.

## Fix

Coerce/normalize the value at the frontmatter boundary before it reaches the strict tRPC schema.

- **`lib/utils.ts`** — new `normalizeAuthors(value: unknown): string[]` helper:
  - scalar → single-item list (`authors: Jane` → `["Jane"]`)
  - list → kept, filtered to non-empty trimmed strings
  - anything malformed (`{foo: bar}`, `2023`, `[Jane, null]`) → filtered / `[]`
  - **never throws**
- **`app/(public)/site/[user]/[project]/[[...slug]]/page.tsx`** — normalize `metadata.authors` before the `getAuthors` query; only query when the result is non-empty. The tRPC schema stays strict as an internal invariant (single call site).
- **`lib/utils.test.ts`** — 6 cases covering the `authors: Jane` regression, wikilink entries, mixed/garbage filtering, empties, and malformed shapes.

## Behavior change

`authors: Jane` now renders Jane as the author (previously: 500 crash). This is silent scalar→array coercion — the least-astonishment reading, matching how sibling static-site tools (Jekyll/Hugo) treat scalar-or-list frontmatter. No docs change in this PR; can be documented as a supported contract as a follow-up if desired.

## Testing

- 12/12 unit tests pass (`npx vitest run --project=unit lib/utils.test.ts`)
- `tsc --noEmit` exit 0
- `eslint` clean

Closes #1354 