### PR TITLE
fix(flowershow): sanitize config on read + validate on write to prevent 500s

### DIFF
--- a/apps/flowershow/app/api/rss/[user]/[project]/route.ts
+++ b/apps/flowershow/app/api/rss/[user]/[project]/route.ts
@@ -76,7 +76,9 @@ export async function GET(
     // missing or invalid config.json — fall back to DB config only
   }
 
-  const siteConfig = resolveSiteConfig(dbConfig, fileConfig);
+  const siteConfig = resolveSiteConfig(dbConfig, fileConfig, {
+    siteId: site.id,
+  });
 
   if (!siteConfig.enableRss) {
     return new Response('Not found', { status: 404 });

--- a/apps/flowershow/lib/site-config-schema.test.ts
+++ b/apps/flowershow/lib/site-config-schema.test.ts
@@ -1,0 +1,330 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { sanitizeSiteConfig, validateConfigPatch } from './site-config-schema';
+
+describe('validateConfigPatch — accepts valid patches', () => {
+  it('accepts an empty patch', () => {
+    expect(() => validateConfigPatch({})).not.toThrow();
+  });
+
+  it('accepts well-formed scalar fields', () => {
+    expect(() =>
+      validateConfigPatch({
+        siteName: 'Brand',
+        description: 'A site',
+        analytics: 'UA-1',
+        syntaxMode: 'md',
+        showToc: true,
+        enableRss: false,
+      }),
+    ).not.toThrow();
+  });
+
+  it('accepts the deprecated `title` field', () => {
+    expect(() => validateConfigPatch({ title: 'Old Brand' })).not.toThrow();
+  });
+
+  it('accepts well-formed nested objects', () => {
+    expect(() =>
+      validateConfigPatch({
+        nav: {
+          title: 'Nav',
+          links: [{ name: 'Home', href: '/' }],
+          logo: '/logo.png',
+          cta: { name: 'Sign up', href: '/signup' },
+        },
+        sidebar: { orderBy: 'title', paths: ['a/', 'b/'] },
+        footer: {
+          navigation: [
+            { title: 'Docs', links: [{ name: 'Guide', href: '/docs' }] },
+          ],
+        },
+        redirects: [{ from: '/old', to: '/new', permanent: true }],
+        contentInclude: ['posts/'],
+      }),
+    ).not.toThrow();
+  });
+
+  // --- polymorphic / deprecated landmines ---
+
+  it('accepts umami in both the string and object forms', () => {
+    expect(() => validateConfigPatch({ umami: 'website-id' })).not.toThrow();
+    expect(() =>
+      validateConfigPatch({ umami: { websiteId: 'w', src: 'https://u.io' } }),
+    ).not.toThrow();
+  });
+
+  it('accepts theme in both the string and object forms', () => {
+    expect(() => validateConfigPatch({ theme: 'forest' })).not.toThrow();
+    expect(() =>
+      validateConfigPatch({
+        theme: { theme: 'dark', defaultMode: 'system', showModeSwitch: true },
+      }),
+    ).not.toThrow();
+  });
+
+  it('accepts hero in both the boolean and object forms', () => {
+    expect(() => validateConfigPatch({ hero: true })).not.toThrow();
+    expect(() =>
+      validateConfigPatch({
+        hero: {
+          title: 'Hi',
+          cta: [{ href: '/x', label: 'Go' }],
+          imagelayout: 'full',
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it('accepts nav.links as a dropdown (union) entry', () => {
+    expect(() =>
+      validateConfigPatch({
+        nav: {
+          links: [
+            { name: 'Home', href: '/' },
+            { name: 'More', links: [{ name: 'Blog', href: '/blog' }] },
+          ],
+        },
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe('validateConfigPatch — allows clearing via null/undefined', () => {
+  it('allows clearing a scalar field with null', () => {
+    expect(() => validateConfigPatch({ description: null })).not.toThrow();
+    expect(() => validateConfigPatch({ analytics: null })).not.toThrow();
+  });
+
+  it('allows clearing a nested field with null (nav.title)', () => {
+    expect(() => validateConfigPatch({ nav: { title: null } })).not.toThrow();
+  });
+
+  it('allows clearing footer.navigation with null', () => {
+    expect(() =>
+      validateConfigPatch({ footer: { navigation: null } }),
+    ).not.toThrow();
+  });
+
+  it('allows the umami { src: null } partial patch (dashboard clears src)', () => {
+    expect(() => validateConfigPatch({ umami: { src: null } })).not.toThrow();
+  });
+
+  it('allows clearing a nested media field with null (image-upload-form)', () => {
+    expect(() => validateConfigPatch({ favicon: null })).not.toThrow();
+    expect(() => validateConfigPatch({ nav: { logo: null } })).not.toThrow();
+  });
+});
+
+describe('validateConfigPatch — rejects bad shapes', () => {
+  it('rejects a wrong-typed scalar', () => {
+    expect(() => validateConfigPatch({ showToc: 'yes' })).toThrow();
+    expect(() => validateConfigPatch({ siteName: 123 })).toThrow();
+  });
+
+  it('rejects an invalid enum value', () => {
+    expect(() => validateConfigPatch({ syntaxMode: 'xml' })).toThrow();
+  });
+
+  it('rejects a flat list of links in footer.navigation', () => {
+    // The exact shape that 500'd portais-cyan-quoisee.flowershow.me.
+    expect(() =>
+      validateConfigPatch({
+        footer: {
+          navigation: [
+            { href: '/blog', name: 'Blog' },
+            { href: '/about', name: 'About' },
+          ],
+        },
+      }),
+    ).toThrow(/footer/i);
+  });
+
+  it('rejects a footer group missing its links array', () => {
+    expect(() =>
+      validateConfigPatch({
+        footer: { navigation: [{ title: 'Broken' }] },
+      }),
+    ).toThrow(/links/i);
+  });
+
+  it('rejects footer.navigation that is not an array', () => {
+    expect(() =>
+      validateConfigPatch({
+        footer: { navigation: { title: 'Docs', links: [] } },
+      }),
+    ).toThrow();
+  });
+
+  it('rejects a malformed social list', () => {
+    expect(() => validateConfigPatch({ social: [{ name: 'X' }] })).toThrow();
+  });
+
+  it('rejects a malformed redirects list', () => {
+    expect(() =>
+      validateConfigPatch({ redirects: [{ from: '/old' }] }),
+    ).toThrow();
+  });
+
+  it('rejects a wrong-typed umami', () => {
+    expect(() => validateConfigPatch({ umami: 123 })).toThrow();
+  });
+});
+
+describe('validateConfigPatch — rejects unknown keys', () => {
+  it('rejects an unknown top-level key', () => {
+    expect(() => validateConfigPatch({ bogusKey: 'x' })).toThrow(/bogusKey/i);
+  });
+
+  it('rejects an unknown nested key in a modeled object', () => {
+    expect(() => validateConfigPatch({ nav: { bogusNavKey: 'x' } })).toThrow();
+  });
+});
+
+describe('sanitizeSiteConfig — never throws', () => {
+  it('returns an empty object for non-object input', () => {
+    expect(sanitizeSiteConfig(null)).toEqual({});
+    expect(sanitizeSiteConfig(undefined)).toEqual({});
+    expect(sanitizeSiteConfig('garbage')).toEqual({});
+    expect(sanitizeSiteConfig(42)).toEqual({});
+    expect(sanitizeSiteConfig([{ nope: true }])).toEqual({});
+  });
+
+  it('returns a well-formed config unchanged', () => {
+    const config = {
+      siteName: 'Brand',
+      description: 'A site',
+      showToc: true,
+      nav: { title: 'Nav', links: [{ name: 'Home', href: '/' }] },
+      footer: {
+        navigation: [
+          { title: 'Docs', links: [{ name: 'Guide', href: '/docs' }] },
+        ],
+      },
+      social: [{ name: 'X', href: 'https://x.com' }],
+    };
+    expect(sanitizeSiteConfig(config)).toEqual(config);
+  });
+});
+
+describe('sanitizeSiteConfig — drops malformed scalar/object fields wholesale', () => {
+  it('drops a wrong-typed scalar but keeps valid siblings', () => {
+    const result = sanitizeSiteConfig({
+      siteName: 123,
+      description: 'kept',
+    });
+    expect(result).toEqual({ description: 'kept' });
+  });
+
+  it('drops a malformed giscus/umami/sidebar/theme/hero wholesale', () => {
+    const result = sanitizeSiteConfig({
+      giscus: 'not-an-object',
+      umami: 123,
+      sidebar: 'nope',
+      theme: 42,
+      hero: 'yes-please',
+      siteName: 'kept',
+    });
+    expect(result).toEqual({ siteName: 'kept' });
+  });
+
+  it('keeps polymorphic valid forms (umami string, theme string, hero boolean, nav dropdown)', () => {
+    const result = sanitizeSiteConfig({
+      umami: 'website-id',
+      theme: 'forest',
+      hero: true,
+      nav: {
+        links: [
+          { name: 'Home', href: '/' },
+          { name: 'More', links: [{ name: 'Blog', href: '/blog' }] },
+        ],
+      },
+    });
+    expect(result).toEqual({
+      umami: 'website-id',
+      theme: 'forest',
+      hero: true,
+      nav: {
+        links: [
+          { name: 'Home', href: '/' },
+          { name: 'More', links: [{ name: 'Blog', href: '/blog' }] },
+        ],
+      },
+    });
+  });
+});
+
+describe('sanitizeSiteConfig — salvages valid list elements', () => {
+  it('drops only the bad group in footer.navigation', () => {
+    const result = sanitizeSiteConfig({
+      footer: {
+        navigation: [
+          { title: 'Docs', links: [{ name: 'Guide', href: '/docs' }] },
+          { title: 'Broken' }, // no links array
+          { name: 'Blog', href: '/blog' }, // flat link, not a group
+        ],
+      },
+    });
+    expect(result.footer?.navigation).toEqual([
+      { title: 'Docs', links: [{ name: 'Guide', href: '/docs' }] },
+    ]);
+  });
+
+  it('drops only the bad entries in nav.links, nav.social, social and redirects', () => {
+    const result = sanitizeSiteConfig({
+      nav: {
+        links: [{ name: 'Home', href: '/' }, { href: '/no-name' }],
+        social: [{ name: 'X', href: 'https://x.com' }, { name: 'bad' }],
+      },
+      social: [{ name: 'GH', href: 'https://gh.com' }, 'nope'],
+      redirects: [
+        { from: '/a', to: '/b' },
+        { from: '/broken' }, // no `to`
+      ],
+    });
+    expect(result.nav?.links).toEqual([{ name: 'Home', href: '/' }]);
+    expect(result.nav?.social).toEqual([{ name: 'X', href: 'https://x.com' }]);
+    expect(result.social).toEqual([{ name: 'GH', href: 'https://gh.com' }]);
+    expect(result.redirects).toEqual([{ from: '/a', to: '/b' }]);
+  });
+
+  it('drops a list field wholesale when it is not an array', () => {
+    const result = sanitizeSiteConfig({
+      social: { name: 'X', href: 'https://x.com' },
+      siteName: 'kept',
+    });
+    expect(result).toEqual({ siteName: 'kept' });
+  });
+});
+
+describe('sanitizeSiteConfig — unknown keys and warnings', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('passes unknown keys through untouched', () => {
+    const result = sanitizeSiteConfig({
+      futureFeature: { enabled: true },
+      siteName: 'Brand',
+    });
+    expect(result).toEqual({
+      futureFeature: { enabled: true },
+      siteName: 'Brand',
+    });
+  });
+
+  it('warns with the siteId and field path on every drop', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    sanitizeSiteConfig(
+      { siteName: 123, footer: { navigation: [{ title: 'Broken' }] } },
+      { siteId: 'site_abc' },
+    );
+    const messages = warn.mock.calls.map((c) => String(c[0]));
+    expect(messages.some((m) => m.includes('siteName'))).toBe(true);
+    expect(messages.some((m) => m.includes('footer.navigation'))).toBe(true);
+    expect(messages.every((m) => m.includes('site_abc'))).toBe(true);
+  });
+
+  it('does not warn for a clean config', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    sanitizeSiteConfig({ siteName: 'Brand', showToc: true });
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/flowershow/lib/site-config-schema.ts
+++ b/apps/flowershow/lib/site-config-schema.ts
@@ -1,0 +1,306 @@
+import { z } from 'zod';
+import type { SiteConfig } from '@/components/types';
+
+/**
+ * Single source of truth for the shape of a site's config (SiteConfig in
+ * components/types.ts). Two strictness modes are derived from these field
+ * schemas:
+ *
+ *  - `validateConfigPatch` (write path) — strict: rejects bad shapes AND
+ *    unknown keys so the dashboard can never persist config that would later
+ *    crash the public site.
+ *  - `sanitizeSiteConfig` (read path) — lenient: never throws; drops or
+ *    salvages malformed fields so a bad config renders as if the bad field was
+ *    simply absent, instead of 500ing every page.
+ */
+
+function isPlainObject(val: unknown): val is Record<string, unknown> {
+  return typeof val === 'object' && val !== null && !Array.isArray(val);
+}
+
+// --- leaf schemas (kept non-strict so extra keys on a link don't disqualify
+// an otherwise-valid entry on the read/salvage path) ---
+const navLinkSchema = z.object({ name: z.string(), href: z.string() });
+const navDropdownSchema = z.object({
+  name: z.string(),
+  links: z.array(navLinkSchema),
+});
+// NavItem = NavLink | NavDropdown. A plain link has `href`; a dropdown has
+// `links`. navLinkSchema is tried first so plain links win the union.
+const navItemSchema = z.union([navLinkSchema, navDropdownSchema]);
+const socialLinkSchema = navLinkSchema.extend({ label: z.string().optional() });
+const footerGroupSchema = z.object({
+  title: z.string(),
+  links: z.array(navLinkSchema),
+});
+const redirectSchema = z.object({
+  from: z.string(),
+  to: z.string(),
+  permanent: z.boolean().optional(),
+});
+const ctaItemSchema = z.object({ href: z.string(), label: z.string() });
+
+// --- container schemas (strict: unknown nested keys are typos worth rejecting
+// on write, since every writer is the machine-generated dashboard UI) ---
+const themeConfigSchema = z.strictObject({
+  theme: z.string().optional(),
+  defaultMode: z.enum(['light', 'dark', 'system']).optional(),
+  showModeSwitch: z.boolean().optional(),
+});
+const heroObjectSchema = z.strictObject({
+  title: z.string().optional(),
+  description: z.string().optional(),
+  image: z.string().optional(),
+  cta: z.array(ctaItemSchema).optional(),
+  imagelayout: z.enum(['right', 'full']).optional(),
+});
+const umamiObjectSchema = z.strictObject({
+  websiteId: z.string().optional(),
+  src: z.string().optional(),
+});
+const navConfigSchema = z.strictObject({
+  title: z.string().optional(),
+  links: z.array(navItemSchema).optional(),
+  cta: navLinkSchema.optional(),
+  logo: z.string().optional(),
+  social: z.array(socialLinkSchema).optional(),
+});
+const footerConfigSchema = z.strictObject({
+  navigation: z.array(footerGroupSchema).optional(),
+});
+const sidebarSchema = z.strictObject({
+  orderBy: z.enum(['title', 'path']).optional(),
+  paths: z.array(z.string()).optional(),
+});
+// giscus is Partial<GiscusProps> — many props, so accept any plain object.
+const giscusSchema = z.record(z.string(), z.unknown());
+
+/**
+ * Field schemas for every SiteConfig key. Required here; the write schema
+ * `.partial()`s them, and the read sanitizer applies them field-by-field.
+ */
+const configShape = {
+  siteName: z.string(),
+  /** @deprecated — kept for existing configs */
+  title: z.string(),
+  description: z.string(),
+  image: z.string(),
+  logo: z.string(),
+  favicon: z.string(),
+  nav: navConfigSchema,
+  footer: footerConfigSchema,
+  social: z.array(socialLinkSchema),
+  analytics: z.string(),
+  umami: z.union([z.string(), umamiObjectSchema]),
+  contentInclude: z.array(z.string()),
+  contentExclude: z.array(z.string()),
+  contentHide: z.array(z.string()),
+  showSidebar: z.boolean(),
+  sidebar: sidebarSchema,
+  showToc: z.boolean(),
+  showKnowledgeGraph: z.boolean(),
+  showEditLink: z.boolean(),
+  showComments: z.boolean(),
+  showBacklinks: z.boolean(),
+  giscus: giscusSchema,
+  redirects: z.array(redirectSchema),
+  theme: z.union([z.string(), themeConfigSchema]),
+  enableSearch: z.boolean(),
+  enableRss: z.boolean(),
+  showBuiltWithButton: z.boolean(),
+  showRawLink: z.boolean(),
+  syntaxMode: z.enum(['auto', 'md', 'mdx']),
+  showHero: z.boolean(),
+  hero: z.union([z.boolean(), heroObjectSchema]),
+  cta: z.array(ctaItemSchema),
+} as const;
+
+/**
+ * Strict, partial schema for a config *patch*: every field optional (patches
+ * touch a subset), bad shapes rejected, unknown top-level keys rejected.
+ */
+export const strictSiteConfigSchema = z.strictObject(configShape).partial();
+
+/**
+ * Recursively removes null/undefined values from plain objects. The dashboard
+ * clears a field by sending `null` (or `undefined`), so those are always valid
+ * and must not trip shape validation. Arrays are left untouched so that a
+ * malformed array element (e.g. `[null]`) still reaches — and is rejected by —
+ * the schema.
+ */
+function stripNullish(value: unknown): unknown {
+  if (!isPlainObject(value)) return value;
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (val === null || val === undefined) continue;
+    out[key] = isPlainObject(val) ? stripNullish(val) : val;
+  }
+  return out;
+}
+
+function formatConfigError(error: z.ZodError): string {
+  const parts = error.issues.map((issue) => {
+    const path = issue.path.join('.');
+    const keys =
+      issue.code === 'unrecognized_keys' && Array.isArray(issue.keys)
+        ? ` (${issue.keys.join(', ')})`
+        : '';
+    return `${path ? `${path}: ` : ''}${issue.message}${keys}`;
+  });
+  return `Invalid site config. ${parts.join('; ')}`;
+}
+
+/**
+ * Validates a site config patch before it is persisted (dashboard → DB
+ * configJson). Throws an Error with a user-facing message on invalid shapes or
+ * unknown keys. `null`/`undefined` values (clearing a field) are always
+ * allowed.
+ */
+export function validateConfigPatch(patch: Record<string, unknown>): void {
+  const cleaned = stripNullish(patch);
+  const result = strictSiteConfigSchema.safeParse(cleaned);
+  if (!result.success) {
+    throw new Error(formatConfigError(result.error));
+  }
+}
+
+type Warn = (path: string) => void;
+
+// List fields that SALVAGE valid elements (drop only the bad ones). Every other
+// field drops wholesale when malformed. nav.links / nav.social /
+// footer.navigation are salvaged inside sanitizeNav / sanitizeFooter.
+const TOP_LEVEL_LIST_FIELDS = {
+  social: socialLinkSchema,
+  redirects: redirectSchema,
+} as const;
+
+/**
+ * Parses an array element-by-element, keeping valid elements and dropping (with
+ * a warning) the invalid ones. Returns `undefined` — signalling a wholesale
+ * drop — when the value is not an array at all.
+ */
+function salvageArray(
+  value: unknown,
+  element: z.ZodType,
+  path: string,
+  warn: Warn,
+): unknown[] | undefined {
+  if (!Array.isArray(value)) {
+    warn(path);
+    return undefined;
+  }
+  const kept: unknown[] = [];
+  value.forEach((el, i) => {
+    const result = element.safeParse(el);
+    if (result.success) kept.push(result.data);
+    else warn(`${path}[${i}]`);
+  });
+  return kept;
+}
+
+function sanitizeNav(
+  value: unknown,
+  warn: Warn,
+): Record<string, unknown> | undefined {
+  if (!isPlainObject(value)) {
+    warn('nav');
+    return undefined;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (key === 'links') {
+      const links = salvageArray(val, navItemSchema, 'nav.links', warn);
+      if (links !== undefined) out.links = links;
+    } else if (key === 'social') {
+      const social = salvageArray(val, socialLinkSchema, 'nav.social', warn);
+      if (social !== undefined) out.social = social;
+    } else if (key === 'title' || key === 'logo') {
+      const result = z.string().safeParse(val);
+      if (result.success) out[key] = result.data;
+      else warn(`nav.${key}`);
+    } else if (key === 'cta') {
+      const result = navLinkSchema.safeParse(val);
+      if (result.success) out.cta = result.data;
+      else warn('nav.cta');
+    } else {
+      out[key] = val; // unknown nested key — pass through
+    }
+  }
+  return out;
+}
+
+function sanitizeFooter(
+  value: unknown,
+  warn: Warn,
+): Record<string, unknown> | undefined {
+  if (!isPlainObject(value)) {
+    warn('footer');
+    return undefined;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (key === 'navigation') {
+      const nav = salvageArray(
+        val,
+        footerGroupSchema,
+        'footer.navigation',
+        warn,
+      );
+      if (nav !== undefined) out.navigation = nav;
+    } else {
+      out[key] = val; // unknown nested key — pass through
+    }
+  }
+  return out;
+}
+
+/**
+ * Lenient read-path sanitizer. Never throws. Malformed fields are dropped (or,
+ * for list fields, have their bad elements dropped) so a bad config renders as
+ * if the offending field were absent, instead of crashing the public site.
+ * Unknown/future keys pass through untouched. Every drop emits a server-side
+ * `console.warn` (with the siteId, when provided) — invisible to the visitor.
+ */
+export function sanitizeSiteConfig(
+  input: unknown,
+  opts?: { siteId?: string },
+): SiteConfig {
+  if (!isPlainObject(input)) return {};
+  const siteId = opts?.siteId;
+  const warn: Warn = (path) =>
+    console.warn(
+      `[site-config] Ignoring invalid config field "${path}"${
+        siteId ? ` for site ${siteId}` : ''
+      }`,
+    );
+
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (key === 'nav') {
+      const nav = sanitizeNav(value, warn);
+      if (nav !== undefined) out.nav = nav;
+      continue;
+    }
+    if (key === 'footer') {
+      const footer = sanitizeFooter(value, warn);
+      if (footer !== undefined) out.footer = footer;
+      continue;
+    }
+    if (key in TOP_LEVEL_LIST_FIELDS) {
+      const element =
+        TOP_LEVEL_LIST_FIELDS[key as keyof typeof TOP_LEVEL_LIST_FIELDS];
+      const salvaged = salvageArray(value, element, key, warn);
+      if (salvaged !== undefined) out[key] = salvaged;
+      continue;
+    }
+    const schema = (configShape as Record<string, z.ZodType>)[key];
+    if (!schema) {
+      out[key] = value; // unknown/future key — pass through
+      continue;
+    }
+    const result = schema.safeParse(value);
+    if (result.success) out[key] = result.data;
+    else warn(key);
+  }
+  return out as SiteConfig;
+}

--- a/apps/flowershow/lib/site-config.test.ts
+++ b/apps/flowershow/lib/site-config.test.ts
@@ -73,6 +73,72 @@ describe('resolveSiteConfig', () => {
     const result = resolveSiteConfig(db, file);
     expect(result.theme).toBe('forest');
   });
+
+  describe('sanitizes each source before merging', () => {
+    it('a malformed field in file config cannot wipe a valid db value', () => {
+      const db = { theme: 'db-theme' };
+      const file = { theme: 123 as never }; // garbage
+      const result = resolveSiteConfig(db, file);
+      expect(result.theme).toBe('db-theme');
+    });
+
+    it('a malformed field in db config is dropped, not merged', () => {
+      const db = { social: 'not-an-array' as never };
+      const file = { siteName: 'Brand' };
+      const result = resolveSiteConfig(db, file);
+      expect(result).toEqual({ siteName: 'Brand' });
+    });
+  });
+
+  describe('opt-in link resolution via siteHostname', () => {
+    const siteHostname = 'sub.flowershow.site';
+
+    it('leaves media paths untouched when no hostname is given', () => {
+      const result = resolveSiteConfig(null, { logo: 'assets/logo.png' });
+      expect(result.logo).toBe('assets/logo.png');
+    });
+
+    it('resolves a media asset to a full URL when a hostname is given', () => {
+      const result = resolveSiteConfig(
+        null,
+        { logo: 'assets/logo.png' },
+        {
+          siteHostname,
+        },
+      );
+      expect(result.logo).toBe(`http://${siteHostname}/assets/logo.png`);
+    });
+
+    it('resolves DB-sourced media links too (not only file-sourced)', () => {
+      const result = resolveSiteConfig({ logo: 'assets/db-logo.png' }, null, {
+        siteHostname,
+      });
+      expect(result.logo).toBe(`http://${siteHostname}/assets/db-logo.png`);
+    });
+
+    it('resolves relative nav.links hrefs but leaves absolute URLs alone', () => {
+      const result = resolveSiteConfig(
+        null,
+        {
+          nav: {
+            links: [
+              { name: 'Blog', href: 'blog/post' },
+              { name: 'Ext', href: 'https://example.com' },
+            ],
+          },
+        },
+        { siteHostname },
+      );
+      const links = result.nav?.links as Array<{ name: string; href: string }>;
+      expect(links[0]!.href).toMatch(/^\//); // relative → resolved to a slug
+      expect(links[1]!.href).toBe('https://example.com'); // absolute untouched
+    });
+
+    it('preserves an emoji logo instead of resolving it as a link', () => {
+      const result = resolveSiteConfig(null, { logo: '🌸' }, { siteHostname });
+      expect(result.logo).toBe('🌸');
+    });
+  });
 });
 
 describe('resolveSiteName', () => {

--- a/apps/flowershow/lib/site-config.ts
+++ b/apps/flowershow/lib/site-config.ts
@@ -1,5 +1,12 @@
-import { z } from 'zod';
-import type { SiteConfig } from '@/components/types';
+import { isNavDropdown, type SiteConfig } from '@/components/types';
+import { isEmoji } from './is-emoji';
+import { resolveContentLink } from './resolve-link';
+import { sanitizeSiteConfig } from './site-config-schema';
+
+export {
+  strictSiteConfigSchema,
+  validateConfigPatch,
+} from './site-config-schema';
 
 // Coerces the legacy string form of umami config (plain website ID) to the
 // canonical object form. The string form is deprecated — use { websiteId, src? }.
@@ -28,46 +35,6 @@ function isPlainObject(val: unknown): val is Record<string, unknown> {
   return typeof val === 'object' && val !== null && !Array.isArray(val);
 }
 
-const navLinkSchema = z.object({
-  name: z.string(),
-  href: z.string(),
-});
-
-/**
- * Shape of `footer.navigation`: an array of groups, each with a `title` and a
- * `links` array of {name, href}. Enforced on save so malformed config (e.g. a
- * flat list of links) can't be persisted and later crash the public Footer,
- * which renders in the layout on every page.
- */
-export const footerNavigationSchema = z.array(
-  z.object({
-    title: z.string(),
-    links: z.array(navLinkSchema),
-  }),
-);
-
-/**
- * Validates a site config patch before it is persisted. Currently guards
- * `footer.navigation`; a `null` value (clearing the field) or an absent field
- * is allowed. Throws an Error with a user-facing message on invalid shapes.
- */
-export function validateConfigPatch(patch: Record<string, unknown>): void {
-  const footer = patch.footer;
-  if (!isPlainObject(footer) || !('navigation' in footer)) return;
-
-  const navigation = footer.navigation;
-  if (navigation == null) return; // clearing the field is allowed
-
-  const result = footerNavigationSchema.safeParse(navigation);
-  if (!result.success) {
-    throw new Error(
-      'Invalid footer navigation. Expected an array of groups, each with a ' +
-        '"title" and a "links" array of { name, href }. ' +
-        'Example: [{"title":"Docs","links":[{"name":"Getting Started","href":"/docs"}]}]',
-    );
-  }
-}
-
 export function deepMerge<T extends Record<string, unknown>>(
   base: T,
   override: Partial<T>,
@@ -89,27 +56,110 @@ export function deepMerge<T extends Record<string, unknown>>(
 }
 
 /**
- * Merges dashboard DB config (configJson) with file-based config (config.json).
- * File config wins: config.json overrides dashboard values.
- * Nested objects are deep-merged; arrays are replaced wholesale.
+ * Rewrites relative media/link targets in a resolved config to their serving
+ * URLs, in place. Mutates only the freshly-sanitized/merged config, never the
+ * caller's input. Emoji logos/favicons are left untouched. Assumes the config
+ * has already been sanitized, so shapes are trustworthy.
+ */
+function resolveConfigLinks(config: SiteConfig, siteHostname: string): void {
+  const resolve = (target: string) =>
+    resolveContentLink({ target, siteHostname });
+  const record = config as Record<string, unknown>;
+
+  // Top-level media paths → full URLs (favicon/logo may be an emoji instead).
+  (['image', 'logo', 'favicon', 'thumbnail'] as const).forEach((key) => {
+    const value = record[key];
+    if (typeof value !== 'string') return;
+    if ((key === 'favicon' || key === 'logo') && isEmoji(value)) return;
+    record[key] = resolve(value);
+  });
+
+  if (config.nav?.links) {
+    config.nav.links.forEach((item) => {
+      if (isNavDropdown(item)) {
+        item.links.forEach((link) => {
+          link.href = resolve(link.href);
+        });
+      } else {
+        item.href = resolve(item.href);
+      }
+    });
+  }
+
+  if (config.nav?.logo && !isEmoji(config.nav.logo)) {
+    config.nav.logo = resolve(config.nav.logo);
+  }
+
+  if (config.nav?.social) {
+    config.nav.social.forEach((social) => {
+      social.href = resolve(social.href);
+    });
+  }
+
+  if (config.nav?.cta) {
+    config.nav.cta.href = resolve(config.nav.cta.href);
+  }
+
+  if (
+    config.hero &&
+    typeof config.hero === 'object' &&
+    !Array.isArray(config.hero)
+  ) {
+    if (typeof config.hero.image === 'string') {
+      config.hero.image = resolve(config.hero.image);
+    }
+    if (Array.isArray(config.hero.cta)) {
+      config.hero.cta.forEach((c) => {
+        if (typeof c?.href === 'string') c.href = resolve(c.href);
+      });
+    }
+  }
+
+  if (Array.isArray(config.footer?.navigation)) {
+    config.footer.navigation.forEach((group) => {
+      if (!Array.isArray(group?.links)) return;
+      group.links.forEach((link) => {
+        link.href = resolve(link.href);
+      });
+    });
+  }
+}
+
+/**
+ * Single pipeline for turning raw DB + file config into a safe, resolved
+ * SiteConfig:
+ *   sanitize(db) → sanitize(file) → deepMerge (file wins) → resolve links.
+ *
+ * Each source is sanitized *before* the merge so malformed data in one source
+ * can't wipe a valid field in the other, and so no malformed field can reach
+ * the public site (which renders config in the layout on every page). File
+ * config wins; nested objects are deep-merged, arrays replaced wholesale.
+ *
+ * Link resolution is opt-in via `opts.siteHostname` — callers that only need
+ * the merged values (RSS, branding) omit it and get no rewriting. Stays
+ * synchronous.
  */
 export function resolveSiteConfig(
   dbConfig: SiteConfig | null | undefined,
   fileConfig: SiteConfig | null | undefined,
+  opts?: { siteHostname?: string; siteId?: string },
 ): SiteConfig {
-  let resolved: SiteConfig;
-  if (!dbConfig && !fileConfig) return {};
-  if (!dbConfig) resolved = fileConfig ?? {};
-  else if (!fileConfig) resolved = dbConfig;
-  else
-    resolved = deepMerge(
-      dbConfig as Record<string, unknown>,
-      fileConfig as Record<string, unknown>,
-    ) as SiteConfig;
+  const db = sanitizeSiteConfig(dbConfig, { siteId: opts?.siteId });
+  const file = sanitizeSiteConfig(fileConfig, { siteId: opts?.siteId });
+
+  let resolved = deepMerge(
+    db as Record<string, unknown>,
+    file as Record<string, unknown>,
+  ) as SiteConfig;
 
   if (resolved.umami !== undefined) {
     resolved = { ...resolved, umami: normalizeUmamiConfig(resolved.umami) };
   }
+
+  if (opts?.siteHostname) {
+    resolveConfigLinks(resolved, opts.siteHostname);
+  }
+
   return resolved;
 }
 

--- a/apps/flowershow/server/api/routers/site.ts
+++ b/apps/flowershow/server/api/routers/site.ts
@@ -5,7 +5,6 @@ import bcrypt from 'bcryptjs';
 import { revalidateTag, unstable_cache } from 'next/cache';
 import { z } from 'zod';
 import type { SiteConfig } from '@/components/types';
-import { isNavDropdown } from '@/components/types';
 import { SiteCreatedEmail } from '@/emails/site-created';
 import { env } from '@/env.mjs';
 import { ANONYMOUS_USER_ID } from '@/lib/anonymous-user';
@@ -942,7 +941,9 @@ export const siteRouter = createTRPCRouter({
           }
 
           const dbConfigJson = (site.configJson ?? null) as SiteConfig | null;
-          const resolved = resolveSiteConfig(dbConfigJson, fileConfig);
+          const resolved = resolveSiteConfig(dbConfigJson, fileConfig, {
+            siteId: site.id,
+          });
           if (!resolved) return null;
 
           // TODO: nav.logo is deprecated in favour of root logo
@@ -1003,121 +1004,26 @@ export const siteRouter = createTRPCRouter({
             site.customDomain ??
             `${site.subdomain}.${env.NEXT_PUBLIC_SITE_DOMAIN}`;
 
+          let fileConfig: SiteConfig | null = null;
           try {
             const configJson = await fetchFile({
               projectId: site.id,
               path: 'config.json',
             });
-            const config = configJson
+            fileConfig = configJson
               ? (JSON.parse(configJson) as SiteConfig)
               : null;
-
-            const dbConfigJson = (site.configJson ?? null) as SiteConfig | null;
-            if (!config)
-              return dbConfigJson
-                ? resolveSiteConfig(dbConfigJson, null)
-                : null;
-
-            // Resolve media paths to full URLs
-            const keysToResolve = ['image', 'logo', 'favicon', 'thumbnail'];
-            keysToResolve.forEach((key) => {
-              if (
-                (key === 'favicon' || key === 'logo') &&
-                config[key] &&
-                isEmoji(config[key])
-              ) {
-                return;
-              }
-
-              if (config[key]) {
-                config[key] = resolveContentLink({
-                  target: config[key],
-                  siteHostname,
-                });
-              }
-            });
-
-            if (config.nav?.links) {
-              config.nav.links.forEach((item) => {
-                if (isNavDropdown(item)) {
-                  item.links.forEach((link) => {
-                    link.href = resolveContentLink({
-                      target: link.href,
-                      siteHostname,
-                    });
-                  });
-                } else {
-                  item.href = resolveContentLink({
-                    target: item.href,
-                    siteHostname,
-                  });
-                }
-              });
-            }
-
-            if (config.nav?.logo && !isEmoji(config.nav.logo)) {
-              config.nav.logo = resolveContentLink({
-                target: config.nav.logo,
-                siteHostname,
-              });
-            }
-
-            if (config.nav?.social) {
-              config.nav.social.forEach((social) => {
-                social.href = resolveContentLink({
-                  target: social.href,
-                  siteHostname,
-                });
-              });
-            }
-
-            if (config.nav?.cta) {
-              config.nav.cta.href = resolveContentLink({
-                target: config.nav.cta.href,
-                siteHostname,
-              });
-            }
-
-            if (
-              config.hero &&
-              typeof config.hero === 'object' &&
-              !Array.isArray(config.hero)
-            ) {
-              if (typeof config.hero.image === 'string') {
-                config.hero.image = resolveContentLink({
-                  target: config.hero.image,
-                  siteHostname,
-                });
-              }
-
-              if (Array.isArray(config.hero.cta)) {
-                config.hero.cta.forEach((c) => {
-                  if (typeof c?.href === 'string') {
-                    c.href = resolveContentLink({
-                      target: c.href,
-                      siteHostname,
-                    });
-                  }
-                });
-              }
-            }
-
-            if (Array.isArray(config.footer?.navigation)) {
-              config.footer.navigation.forEach((group) => {
-                if (!Array.isArray(group?.links)) return;
-                group.links.forEach((link) => {
-                  link.href = resolveContentLink({
-                    target: link.href,
-                    siteHostname,
-                  });
-                });
-              });
-            }
-
-            return resolveSiteConfig(dbConfigJson, config);
           } catch {
-            return null;
+            // missing or invalid config.json — fall back to DB config only
           }
+
+          const dbConfigJson = (site.configJson ?? null) as SiteConfig | null;
+          if (!fileConfig && !dbConfigJson) return null;
+
+          return resolveSiteConfig(dbConfigJson, fileConfig, {
+            siteHostname,
+            siteId: site.id,
+          });
         },
         undefined,
         {


### PR DESCRIPTION
## Problem

`f74b9ff` guarded one field (`footer.navigation`) after a malformed value 500'd every page of a site. But the site config has ~30 fields, and **any** malformed field in `config.json` (file) or `site.configJson` (DB) can crash the public site the same way — the config is read in the layout, so one bad field = HTTP 500 on every page. Config was validated on neither read nor write (beyond that one field).

This extends the `f74b9ff` pattern to the whole config, on both the read and write side.

## Approach

**One strict Zod schema** models every `SiteConfig` field (incl. the polymorphic/deprecated landmines: `umami` string|object, `theme` string|object, `hero` boolean|object, the `nav.links` `NavLink|NavDropdown` union). It drives two derived behaviors:

- **Write (`validateConfigPatch`)** — strict + partial. Rejects bad shapes **and** unknown keys (`BAD_REQUEST`) on every dashboard save path, not just the editor. Safe to be strict because the only writer of `configJson` is the machine-generated dashboard UI. Clearing a field with `null`/`undefined` and partial nested patches (`{nav:{title:null}}`, `{umami:{src:null}}`) always pass.
- **Read (`sanitizeSiteConfig`)** — a lenient sanitizer that **never throws**. Salvages valid elements from list fields (`footer.navigation`, `nav.links`, `nav.social`, `social`, `redirects`), drops malformed scalar/object fields wholesale, passes unknown/future keys through, and `console.warn`s each drop (with `siteId` + field path) — silent to the visitor.

**`resolveSiteConfig` is now the single pipeline:** `sanitize(db) → sanitize(file) → deepMerge (file wins) → resolve links (opt-in via siteHostname)`. Each source is sanitized *before* merge, so garbage in one source can't wipe a valid field in the other. The inline link-rewriter moved out of `getConfig` into `resolveSiteConfig`.

## Intended behavior changes (both wanted)

- **DB-sourced links now get resolved too** (the rewriter runs post-merge instead of on file-config only). Idempotent for already-absolute URLs, so stored `publicUrl`s are untouched.
- A malformed `config.json` now **falls back to DB config** instead of nulling the whole config.

No React error boundary — read-side safety relies on the sanitizer + passthrough. Existing footer runtime guards kept as belt-and-suspenders.

## Tests

Written failing-first (per `f74b9ff`). New coverage: the strict validator (bad shapes, unknown keys, null-clearing, polymorphic forms), the lenient sanitizer (salvage vs wholesale-drop, passthrough, never-throws, warns), and the pipeline (sanitize-before-merge, opt-in link resolution incl. the DB-link bugfix). Existing 8 merge tests + footer tests unchanged and green.

- ✅ Full unit suite: 570 passed / 40 files
- ✅ `tsc --noEmit`: 0 errors
- ✅ ESLint clean