### PR TITLE
fix(dashboard): block claiming one of our own domains as a custom domain

### DIFF
--- a/apps/flowershow/components/dashboard/form/index.test.tsx
+++ b/apps/flowershow/components/dashboard/form/index.test.tsx
@@ -83,6 +83,19 @@ describe('Form — custom domain validation', () => {
     expect(handleSubmit).not.toHaveBeenCalled();
   });
 
+  // Users are auto-assigned a *.flowershow.me subdomain, so they must not be
+  // able to claim one of our own domains as a custom domain.
+  it('rejects a flowershow.me subdomain before submitting', async () => {
+    const handleSubmit = renderCustomDomainForm('');
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'tom.flowershow.me' } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+
   it('submits a valid domain', async () => {
     const handleSubmit = renderCustomDomainForm('');
 

--- a/apps/flowershow/components/dashboard/form/index.test.tsx
+++ b/apps/flowershow/components/dashboard/form/index.test.tsx
@@ -83,13 +83,14 @@ describe('Form — custom domain validation', () => {
     expect(handleSubmit).not.toHaveBeenCalled();
   });
 
-  // Users are auto-assigned a *.flowershow.me subdomain, so they must not be
-  // able to claim one of our own domains as a custom domain.
-  it('rejects a flowershow.me subdomain before submitting', async () => {
+  // Users are auto-assigned a subdomain on our site domain, so they must not be
+  // able to claim one of our own domains as a custom domain. The configured
+  // NEXT_PUBLIC_SITE_DOMAIN in tests is `test.localhost` (see vitest.setup.ts).
+  it('rejects a subdomain of our site domain before submitting', async () => {
     const handleSubmit = renderCustomDomainForm('');
 
     const input = screen.getByRole('textbox');
-    fireEvent.change(input, { target: { value: 'tom.flowershow.me' } });
+    fireEvent.change(input, { target: { value: 'tom.test.localhost' } });
     fireEvent.click(screen.getByRole('button', { name: /save/i }));
 
     await waitFor(() => expect(toastError).toHaveBeenCalled());

--- a/apps/flowershow/components/dashboard/form/index.tsx
+++ b/apps/flowershow/components/dashboard/form/index.tsx
@@ -6,6 +6,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { type FormEvent, type ReactNode, useState } from 'react';
 import { toast } from 'sonner';
 import LoadingDots from '@/components/icons/loading-dots';
+import { isReservedDomain } from '@/lib/domains';
 import type { SiteUpdateKey } from '@/server/api/types';
 import DomainConfiguration from './domain-configuration';
 import DomainStatus from './domain-status';
@@ -94,6 +95,17 @@ export default function Form({
           'Error: Site name must contain at least one letter or number and cannot contain "/"',
         );
       }
+      return;
+    }
+
+    if (
+      inputAttrs.name === 'customDomain' &&
+      value.trim() !== '' &&
+      isReservedDomain(value)
+    ) {
+      toast.error(
+        'This domain is not available. Please enter a domain you own.',
+      );
       return;
     }
 

--- a/apps/flowershow/lib/domains.test.ts
+++ b/apps/flowershow/lib/domains.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// lib/domains imports env (used by the Vercel API helpers); stub it so the
+// module can be imported in isolation.
+vi.mock('@/env.mjs', () => ({
+  env: {
+    NEXT_PUBLIC_VERCEL_ENV: 'production',
+    PROJECT_ID_VERCEL: 'prj_test',
+    TEAM_ID_VERCEL: 'team_test',
+    AUTH_BEARER_TOKEN: 'token_test',
+  },
+}));
+
+// Must import AFTER mocking
+const { isReservedDomain } = await import('./domains');
+
+describe('isReservedDomain', () => {
+  it.each([
+    'flowershow.me',
+    'tom.flowershow.me',
+    'my.site.flowershow.me',
+    'flowershow.app',
+    'docs.flowershow.app',
+    'flowershow.site',
+    'FlowerShow.ME', // case-insensitive
+    'tom.flowershow.me.', // trailing dot (FQDN)
+  ])('rejects our own domain: %s', (domain) => {
+    expect(isReservedDomain(domain)).toBe(true);
+  });
+
+  it.each([
+    'example.com',
+    'tom.dev',
+    'flowershow.example.com', // flowershow is a subdomain label, not ours
+    'notflowershow.me', // not the flowershow apex
+    'myflowershow.com',
+  ])('allows a domain the user owns: %s', (domain) => {
+    expect(isReservedDomain(domain)).toBe(false);
+  });
+});

--- a/apps/flowershow/lib/domains.test.ts
+++ b/apps/flowershow/lib/domains.test.ts
@@ -1,13 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 
-// lib/domains imports env (used by the Vercel API helpers); stub it so the
-// module can be imported in isolation.
+// isReservedDomain derives the blocked domains from these two config values
+// (SITE_DOMAIN = where user subdomains live, HOME_DOMAIN = marketing/docs).
 vi.mock('@/env.mjs', () => ({
   env: {
-    NEXT_PUBLIC_VERCEL_ENV: 'production',
-    PROJECT_ID_VERCEL: 'prj_test',
-    TEAM_ID_VERCEL: 'team_test',
-    AUTH_BEARER_TOKEN: 'token_test',
+    NEXT_PUBLIC_SITE_DOMAIN: 'flowershow.me',
+    NEXT_PUBLIC_HOME_DOMAIN: 'flowershow.app',
   },
 }));
 
@@ -16,12 +14,11 @@ const { isReservedDomain } = await import('./domains');
 
 describe('isReservedDomain', () => {
   it.each([
-    'flowershow.me',
-    'tom.flowershow.me',
-    'my.site.flowershow.me',
-    'flowershow.app',
-    'docs.flowershow.app',
-    'flowershow.site',
+    'flowershow.me', // SITE_DOMAIN apex
+    'tom.flowershow.me', // subdomain of SITE_DOMAIN
+    'my.site.flowershow.me', // deep subdomain of SITE_DOMAIN
+    'flowershow.app', // HOME_DOMAIN apex
+    'docs.flowershow.app', // subdomain of HOME_DOMAIN
     'FlowerShow.ME', // case-insensitive
     'tom.flowershow.me.', // trailing dot (FQDN)
   ])('rejects our own domain: %s', (domain) => {
@@ -31,8 +28,10 @@ describe('isReservedDomain', () => {
   it.each([
     'example.com',
     'tom.dev',
+    'flowershow.org', // a different TLD we don't operate
+    'flowershow.site', // not one of the configured base domains
     'flowershow.example.com', // flowershow is a subdomain label, not ours
-    'notflowershow.me', // not the flowershow apex
+    'notflowershow.me', // not the SITE_DOMAIN apex
     'myflowershow.com',
   ])('allows a domain the user owns: %s', (domain) => {
     expect(isReservedDomain(domain)).toBe(false);

--- a/apps/flowershow/lib/domains.ts
+++ b/apps/flowershow/lib/domains.ts
@@ -161,3 +161,13 @@ export const getApexDomain = (url: string) => {
 export const validDomainRegex = new RegExp(
   /^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/,
 );
+
+// Domains we own and manage. Users are automatically assigned a
+// `<site>-<user>.flowershow.me` subdomain, so they must not be allowed to point
+// a "custom domain" at any flowershow.* domain (e.g. tom.flowershow.me) — that
+// would let them squat on our namespace. Matches the apex and any subdomain of
+// a flowershow.* domain by checking that "flowershow" is the second-level label.
+export const isReservedDomain = (domain: string) => {
+  const labels = domain.trim().toLowerCase().replace(/\.$/, '').split('.');
+  return labels.length >= 2 && labels[labels.length - 2] === 'flowershow';
+};

--- a/apps/flowershow/lib/domains.ts
+++ b/apps/flowershow/lib/domains.ts
@@ -162,12 +162,29 @@ export const validDomainRegex = new RegExp(
   /^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/,
 );
 
-// Domains we own and manage. Users are automatically assigned a
-// `<site>-<user>.flowershow.me` subdomain, so they must not be allowed to point
-// a "custom domain" at any flowershow.* domain (e.g. tom.flowershow.me) — that
-// would let them squat on our namespace. Matches the apex and any subdomain of
-// a flowershow.* domain by checking that "flowershow" is the second-level label.
+const normalizeHost = (host: string) =>
+  host
+    .trim()
+    .toLowerCase()
+    .replace(/\.$/, '') // trailing dot (FQDN form)
+    .replace(/:\d+$/, ''); // port (dev domains carry one, e.g. localhost:3000)
+
+// Domains we own and operate: the base domain for auto-assigned user subdomains
+// (SITE_DOMAIN, e.g. a `<site>-<user>` subdomain) and the marketing/docs domain
+// (HOME_DOMAIN). Derived from config so nothing is hardcoded.
+const reservedBaseDomains = () =>
+  [env.NEXT_PUBLIC_SITE_DOMAIN, env.NEXT_PUBLIC_HOME_DOMAIN]
+    .map(normalizeHost)
+    .filter(Boolean);
+
+// A custom domain must not point at one of our own domains — that would let a
+// user squat on our namespace (e.g. tom.<SITE_DOMAIN>). Matches each base apex
+// and any subdomain of it, but leaves unrelated domains (flowershow.org, a
+// user's own domain) untouched.
 export const isReservedDomain = (domain: string) => {
-  const labels = domain.trim().toLowerCase().replace(/\.$/, '').split('.');
-  return labels.length >= 2 && labels[labels.length - 2] === 'flowershow';
+  const host = normalizeHost(domain);
+  if (!host) return false;
+  return reservedBaseDomains().some(
+    (base) => host === base || host.endsWith(`.${base}`),
+  );
 };

--- a/apps/flowershow/server/api/routers/site.ts
+++ b/apps/flowershow/server/api/routers/site.ts
@@ -309,8 +309,8 @@ export const siteRouter = createTRPCRouter({
             message: 'Custom domains require a Premium plan',
           });
         }
-        // Users get an auto-assigned *.flowershow.me subdomain; they must not be
-        // able to claim one of our own domains as a "custom domain".
+        // Users get an auto-assigned subdomain on our site domain; they must not
+        // be able to claim one of our own domains as a "custom domain".
         if (newDomain && isReservedDomain(newDomain)) {
           throw new TRPCError({
             code: 'BAD_REQUEST',

--- a/apps/flowershow/server/api/routers/site.ts
+++ b/apps/flowershow/server/api/routers/site.ts
@@ -20,6 +20,7 @@ import {
 import {
   addDomainToVercel,
   getDomainVariant,
+  isReservedDomain,
   removeDomainAndVariantFromVercelProject,
   validDomainRegex,
 } from '@/lib/domains';
@@ -306,6 +307,15 @@ export const siteRouter = createTRPCRouter({
           throw new TRPCError({
             code: 'FORBIDDEN',
             message: 'Custom domains require a Premium plan',
+          });
+        }
+        // Users get an auto-assigned *.flowershow.me subdomain; they must not be
+        // able to claim one of our own domains as a "custom domain".
+        if (newDomain && isReservedDomain(newDomain)) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message:
+              'This domain is not available. Please enter a domain you own.',
           });
         }
         if (!newDomain) {


### PR DESCRIPTION
## Problem

Users publishing on Flowershow get an auto-assigned subdomain on our site domain. But the **Custom Domain** setting accepted *any* regex-valid domain — including our own (e.g. a subdomain of the site domain). That let a user point a "custom domain" at our namespace and squat on one of our hostnames.

## Fix

- **`isReservedDomain()`** (`lib/domains.ts`) — derives the blocked set from config (`NEXT_PUBLIC_SITE_DOMAIN` + `NEXT_PUBLIC_HOME_DOMAIN`) and rejects each base apex and any subdomain of it. Nothing is hardcoded, so it tracks whatever those domains are set to per environment. Normalizes case, trailing FQDN dots, and dev port suffixes (`localhost:3000`).
- **Server enforcement (authoritative)** — the `site.update` tRPC mutation rejects a reserved domain with `BAD_REQUEST`, placed before the prod/non-prod branch so it applies in **every** environment, before anything touches the DB or Vercel.
- **Client feedback** — the dashboard form shows an immediate toast instead of waiting on a round-trip.

The dashboard's HTML `pattern` still matches a reserved domain (it's structurally valid), so the mutation guard is the real block; the client check is UX only.

### Scope
Blocks only the two domains we actually operate and their subdomains. Unrelated domains a user might legitimately own — e.g. `flowershow.org` or any other TLD — are **not** blocked.

## Tests
- `lib/domains.test.ts` (new) — covers rejected (apex + subdomains of both base domains, case-insensitive, FQDN) and allowed (`flowershow.org`, other TLDs, unrelated domains).
- `components/dashboard/form/index.test.tsx` — added a reserved-subdomain rejection case (uses the test env's configured site domain).
- `server/api/routers/__tests__/site.test.ts` — 43 existing tests still pass.

All green; typecheck clean.
