### PR TITLE
docs: publish semantic theme class reference

### DIFF
--- a/content/flowershow-app/docs/reference/custom-styles.md
+++ b/content/flowershow-app/docs/reference/custom-styles.md
@@ -11,6 +11,11 @@ description: Customize the appearance of your site with CSS.
 
 Flowershow uses CSS cascade layers, so any rule you write in `custom.css` wins over the default theme without needing `!important`.
 
+Start with the theme variables below for broad visual changes. When you need to
+target a particular component or state, use the
+[semantic theme class reference](/docs/reference/theme-class-reference), which
+groups Flowershow's stable CSS hooks by the UI area that emits them.
+
 ## Theme variables
 
 Flowershow exposes CSS custom properties (variables) in `:root`.

--- a/content/flowershow-app/docs/reference/theme-class-reference.md
+++ b/content/flowershow-app/docs/reference/theme-class-reference.md
@@ -186,7 +186,7 @@ Page identity, hero content, Markdown body, code controls, images, and task-list
 
 ```text
 .page-hero-container
-└─ .page-hero[.has-image]
+└─ .page-hero[.has-image | .image-full]
 main.page-main (structural wrapper)
 ├─ .page-header
 │  ├─ .page-header-title
@@ -200,7 +200,6 @@ main.page-main (structural wrapper)
 | --- | --- |
 | <code>.contains-task-list</code> | Hook |
 | <code>.heading-link</code> | Hook |
-| <code>.image-full</code> | Hook |
 | <code>.page-header</code> | Hook |
 | <code>.page-header-author-avatar</code> | Hook |
 | <code>.page-header-author-name</code> | Hook |
@@ -480,15 +479,15 @@ Public error cards, diagnostic stacks, and 404 presentation.
 | <code>.not-found-subtitle</code> | Hook |
 | <code>.not-found-title</code> | Hook |
 
-## Shared states
+## Shared states and layout variants
 
-Conditional presence, open/current, image, and layout states.
+Conditional presence, open/current, image, and layout modifiers.
 
 **DOM shape**
 
 ```text
 Owning semantic hook
-└─ .is-* / .has-* / .no-*
+└─ .is-* / .has-* / .no-* / .image-full
 ```
 
 | Class | Kind | Owner |
@@ -497,6 +496,7 @@ Owning semantic hook
 | <code>.has-sidebar</code> | State | .layout-inner |
 | <code>.has-sidebar-and-toc</code> | State | .layout-inner |
 | <code>.has-toc</code> | State | .layout-inner |
+| <code>.image-full</code> | Variant | .page-hero |
 | <code>.is-collapsible</code> | State | .site-tree-item-self / .mobile-nav-tree-item-self |
 | <code>.is-current</code> | State | .site-tree-item-self / .mobile-nav-tree-item-self |
 | <code>.is-open</code> | State | navigation dropdowns and collapsible tree items |

--- a/content/flowershow-app/docs/reference/theme-class-reference.md
+++ b/content/flowershow-app/docs/reference/theme-class-reference.md
@@ -7,20 +7,29 @@ Flowershow themes start with [custom properties](/docs/reference/custom-styles),
 then use semantic classes when a component needs more specific treatment. This
 page is generated from
 [`default-theme.css`](https://github.com/flowershow/flowershow/blob/main/apps/flowershow/styles/default-theme.css)
-and currently documents **230 unique class hooks**.
+and currently documents **230 styled class selectors**:
+**228 stable semantic hooks** and **2 non-contract
+compatibility utilities**.
 
 ## Stability contract
 
-The component and element hooks listed here are a public theme-author API.
+The semantic component, element, state, and variant hooks listed here are a
+public theme-author API.
 Removing or renaming one, or changing what UI element it represents, is a
 breaking change for themes. Adding a hook is non-breaking. State and Variant
 hooks are stable in name but only appear when their owning component enters
 that state; do not assume every page renders every hook.
 
-The list is exhaustive for classes styled by `default-theme.css`. Raw utility
-classes used only inside component source are not an authoring contract unless
-they also appear here. Structure is still controlled by Flowershow core: these
-hooks change presentation, not which components render or their order.
+The list is exhaustive for classes styled by `default-theme.css`. The final
+compatibility section is drift-checked but explicitly excluded from the public
+API. Emitted-only class names and raw utility classes used inside component
+source are not an authoring contract unless they appear in a semantic table on
+this page.
+
+Structural wrappers shown in DOM sketches but absent from their accompanying
+tables provide nesting context only; they are not stable hooks. Structure is
+still controlled by Flowershow core: these hooks change presentation, not which
+components render or their order.
 
 Kinds used below:
 
@@ -28,6 +37,7 @@ Kinds used below:
 - **Element** — BEM-style child written with `__`.
 - **Variant** — alternative treatment written with `--`.
 - **State** — conditional `is-*`, `has-*`, or `no-*` hook.
+- **Compatibility** — styled utility retained for compatibility, not public API.
 
 ## Related non-class hooks
 
@@ -49,10 +59,16 @@ Top-level site grid, responsive rails, and shell variants.
 
 ```text
 .site-layout[.no-nav]
-└─ .layout-inner[.has-sidebar][.has-toc]
-   ├─ .layout-inner-left
-   ├─ main
-   └─ .layout-inner-right
+├─ .site-navbar (optional)
+├─ .site-body (structural wrapper)
+│  ├─ .site-subnav (optional)
+│  ├─ .page-hero-container (optional)
+│  └─ .layout-inner[.has-sidebar | .has-toc | .has-sidebar-and-toc]
+│     ├─ .layout-inner-left
+│     ├─ .layout-inner-center (structural wrapper)
+│     │  └─ main.page-main (structural wrapper)
+│     └─ .layout-inner-right
+└─ .site-footer
 ```
 
 | Class | Kind |
@@ -70,13 +86,13 @@ Desktop navbar, dropdowns, mobile navigation, theme switch, and visitor controls
 
 ```text
 .site-navbar
-└─ .site-navbar-inner
-   ├─ .site-navbar-site-name
-   ├─ .site-navbar-links-container
-   │  ├─ .site-navbar-link
-   │  └─ .site-navbar-dropdown
-   └─ .site-navbar-mobile-nav-button
-      └─ .mobile-nav
+├─ .site-navbar-inner
+│  ├─ .site-navbar-site-name
+│  ├─ .site-navbar-links-container
+│  │  ├─ .site-navbar-link
+│  │  └─ .site-navbar-dropdown
+│  └─ .site-navbar-mobile-nav-button
+└─ .mobile-nav
 ```
 
 | Class | Kind |
@@ -131,11 +147,12 @@ Breadcrumbs, desktop site tree, and the small-screen sidebar drawer.
 .site-subnav
 ├─ .site-subnav-breadcrumbs
 └─ .site-subnav-menu-button
-.site-sidebar / .sidebar-drawer-panel
-└─ .site-tree
-   └─ .site-tree-item
-      ├─ .site-tree-item-self
-      └─ .site-tree-item-children
+.layout-inner-left
+└─ .site-sidebar
+   └─ .site-tree
+body (dialog portal)
+└─ .sidebar-drawer-panel
+   └─ .site-tree
 ```
 
 | Class | Kind |
@@ -168,14 +185,15 @@ Page identity, hero content, Markdown body, code controls, images, and task-list
 **DOM shape**
 
 ```text
-.page-hero
-└─ .page-hero-container
-main
+.page-hero-container
+└─ .page-hero[.has-image]
+main.page-main (structural wrapper)
 ├─ .page-header
 │  ├─ .page-header-title
 │  ├─ .page-header-description
 │  └─ .page-header-metadata-container
-└─ .rendered-mdx
+└─ .page-body (structural wrapper)
+   └─ .rendered-mdx[.is-plain]
 ```
 
 | Class | Kind |
@@ -209,7 +227,6 @@ main
 | <code>.pre-copy-button</code> | Hook |
 | <code>.pre-icon</code> | Hook |
 | <code>.pre-sr</code> | Hook |
-| <code>.prose</code> | Hook |
 | <code>.rendered-mdx</code> | Hook |
 
 ## Table of contents
@@ -374,7 +391,8 @@ Blocks rendered after the main page content.
 **DOM shape**
 
 ```text
-main
+.layout-inner-center (structural wrapper)
+├─ main.page-main (structural wrapper)
 ├─ .page-edit-button-container
 ├─ .page-backlinks-container
 │  └─ .page-backlinks-list
@@ -462,30 +480,46 @@ Public error cards, diagnostic stacks, and 404 presentation.
 | <code>.not-found-subtitle</code> | Hook |
 | <code>.not-found-title</code> | Hook |
 
-## Shared states and utility hooks
+## Shared states
 
-Cross-component presence, open/current, scrolling, image, and layout state classes.
+Conditional presence, open/current, image, and layout states.
 
 **DOM shape**
 
 ```text
-Owning component
-└─ .is-* / .has-* / .no-* / shared utility hook
+Owning semantic hook
+└─ .is-* / .has-* / .no-*
+```
+
+| Class | Kind | Owner |
+| --- | --- | --- |
+| <code>.has-image</code> | State | .page-hero |
+| <code>.has-sidebar</code> | State | .layout-inner |
+| <code>.has-sidebar-and-toc</code> | State | .layout-inner |
+| <code>.has-toc</code> | State | .layout-inner |
+| <code>.is-collapsible</code> | State | .site-tree-item-self / .mobile-nav-tree-item-self |
+| <code>.is-current</code> | State | .site-tree-item-self / .mobile-nav-tree-item-self |
+| <code>.is-open</code> | State | navigation dropdowns and collapsible tree items |
+| <code>.is-plain</code> | State | .rendered-mdx |
+| <code>.is-scrolled</code> | State | .site-navbar |
+| <code>.no-nav</code> | State | .site-layout |
+
+## Compatibility utilities (not public API)
+
+Selectors retained for exhaustive drift tracking but excluded from the semantic theme-author contract.
+
+**CSS layer**
+
+```text
+@layer utilities
+├─ .prose
+└─ .overflow-hidden
 ```
 
 | Class | Kind |
 | --- | --- |
-| <code>.has-image</code> | State |
-| <code>.has-sidebar</code> | State |
-| <code>.has-sidebar-and-toc</code> | State |
-| <code>.has-toc</code> | State |
-| <code>.is-collapsible</code> | State |
-| <code>.is-current</code> | State |
-| <code>.is-open</code> | State |
-| <code>.is-plain</code> | State |
-| <code>.is-scrolled</code> | State |
-| <code>.no-nav</code> | State |
-| <code>.overflow-hidden</code> | Hook |
+| <code>.overflow-hidden</code> | Compatibility |
+| <code>.prose</code> | Compatibility |
 
 ---
 

--- a/content/flowershow-app/docs/reference/theme-class-reference.md
+++ b/content/flowershow-app/docs/reference/theme-class-reference.md
@@ -1,0 +1,494 @@
+---
+title: Semantic theme class reference
+description: Stable Flowershow CSS hooks grouped by the UI areas that emit them.
+---
+
+Flowershow themes start with [custom properties](/docs/reference/custom-styles),
+then use semantic classes when a component needs more specific treatment. This
+page is generated from
+[`default-theme.css`](https://github.com/flowershow/flowershow/blob/main/apps/flowershow/styles/default-theme.css)
+and currently documents **230 unique class hooks**.
+
+## Stability contract
+
+The component and element hooks listed here are a public theme-author API.
+Removing or renaming one, or changing what UI element it represents, is a
+breaking change for themes. Adding a hook is non-breaking. State and Variant
+hooks are stable in name but only appear when their owning component enters
+that state; do not assume every page renders every hook.
+
+The list is exhaustive for classes styled by `default-theme.css`. Raw utility
+classes used only inside component source are not an authoring contract unless
+they also appear here. Structure is still controlled by Flowershow core: these
+hooks change presentation, not which components render or their order.
+
+Kinds used below:
+
+- **Hook** — component or semantic element.
+- **Element** — BEM-style child written with `__`.
+- **Variant** — alternative treatment written with `--`.
+- **State** — conditional `is-*`, `has-*`, or `no-*` hook.
+
+## Related non-class hooks
+
+Callouts use data attributes rather than classes:
+
+- `[data-callout]`
+- `[data-callout-type="note"]` (and other callout types)
+- `[data-callout-title]`
+- `[data-callout-body]`
+
+Scope callout overrides below `.rendered-mdx` so they outrank the base
+attribute selectors without relying on source order.
+
+## Site layout and page shell
+
+Top-level site grid, responsive rails, and shell variants.
+
+**DOM shape**
+
+```text
+.site-layout[.no-nav]
+└─ .layout-inner[.has-sidebar][.has-toc]
+   ├─ .layout-inner-left
+   ├─ main
+   └─ .layout-inner-right
+```
+
+| Class | Kind |
+| --- | --- |
+| <code>.layout-inner</code> | Hook |
+| <code>.layout-inner-left</code> | Hook |
+| <code>.layout-inner-right</code> | Hook |
+| <code>.site-layout</code> | Hook |
+
+## Navbar and mobile navigation
+
+Desktop navbar, dropdowns, mobile navigation, theme switch, and visitor controls.
+
+**DOM shape**
+
+```text
+.site-navbar
+└─ .site-navbar-inner
+   ├─ .site-navbar-site-name
+   ├─ .site-navbar-links-container
+   │  ├─ .site-navbar-link
+   │  └─ .site-navbar-dropdown
+   └─ .site-navbar-mobile-nav-button
+      └─ .mobile-nav
+```
+
+| Class | Kind |
+| --- | --- |
+| <code>.mobile-nav</code> | Hook |
+| <code>.mobile-nav-cta-button</code> | Hook |
+| <code>.mobile-nav-dropdown</code> | Hook |
+| <code>.mobile-nav-dropdown-icon</code> | Hook |
+| <code>.mobile-nav-dropdown-item</code> | Hook |
+| <code>.mobile-nav-dropdown-panel</code> | Hook |
+| <code>.mobile-nav-dropdown-trigger</code> | Hook |
+| <code>.mobile-nav-link</code> | Hook |
+| <code>.mobile-nav-links-container</code> | Hook |
+| <code>.mobile-nav-social-link</code> | Hook |
+| <code>.mobile-nav-social-links-container</code> | Hook |
+| <code>.mobile-nav-tree</code> | Hook |
+| <code>.mobile-nav-tree-container</code> | Hook |
+| <code>.mobile-nav-tree-item-children</code> | Hook |
+| <code>.mobile-nav-tree-item-icon</code> | Hook |
+| <code>.mobile-nav-tree-item-self</code> | Hook |
+| <code>.site-navbar</code> | Hook |
+| <code>.site-navbar-cta-button</code> | Hook |
+| <code>.site-navbar-dropdown</code> | Hook |
+| <code>.site-navbar-dropdown-icon</code> | Hook |
+| <code>.site-navbar-dropdown-item</code> | Hook |
+| <code>.site-navbar-dropdown-panel</code> | Hook |
+| <code>.site-navbar-dropdown-trigger</code> | Hook |
+| <code>.site-navbar-inner</code> | Hook |
+| <code>.site-navbar-link</code> | Hook |
+| <code>.site-navbar-links-container</code> | Hook |
+| <code>.site-navbar-mobile-nav-button</code> | Hook |
+| <code>.site-navbar-mobile-nav-icon</code> | Hook |
+| <code>.site-navbar-search-container</code> | Hook |
+| <code>.site-navbar-site-logo</code> | Hook |
+| <code>.site-navbar-site-name</code> | Hook |
+| <code>.site-navbar-site-title</code> | Hook |
+| <code>.site-navbar-social-link-icon</code> | Hook |
+| <code>.site-navbar-social-links-container</code> | Hook |
+| <code>.site-navbar-theme-switch-container</code> | Hook |
+| <code>.theme-switch</code> | Hook |
+| <code>.theme-switch-icon</code> | Hook |
+| <code>.visitor-logout-button</code> | Hook |
+| <code>.visitor-logout-button-icon</code> | Hook |
+
+## Subnavigation, sidebar, and site tree
+
+Breadcrumbs, desktop site tree, and the small-screen sidebar drawer.
+
+**DOM shape**
+
+```text
+.site-subnav
+├─ .site-subnav-breadcrumbs
+└─ .site-subnav-menu-button
+.site-sidebar / .sidebar-drawer-panel
+└─ .site-tree
+   └─ .site-tree-item
+      ├─ .site-tree-item-self
+      └─ .site-tree-item-children
+```
+
+| Class | Kind |
+| --- | --- |
+| <code>.sidebar-drawer-backdrop</code> | Hook |
+| <code>.sidebar-drawer-close</code> | Hook |
+| <code>.sidebar-drawer-close-icon</code> | Hook |
+| <code>.sidebar-drawer-header</code> | Hook |
+| <code>.sidebar-drawer-panel</code> | Hook |
+| <code>.site-sidebar</code> | Hook |
+| <code>.site-subnav</code> | Hook |
+| <code>.site-subnav-breadcrumb-item</code> | Hook |
+| <code>.site-subnav-breadcrumb-link</code> | Hook |
+| <code>.site-subnav-breadcrumbs</code> | Hook |
+| <code>.site-subnav-menu-button</code> | Hook |
+| <code>.site-subnav-menu-icon</code> | Hook |
+| <code>.site-subnav-separator</code> | Hook |
+| <code>.site-tree</code> | Hook |
+| <code>.site-tree-disclosure-panel</code> | Hook |
+| <code>.site-tree-item</code> | Hook |
+| <code>.site-tree-item-children</code> | Hook |
+| <code>.site-tree-item-icon</code> | Hook |
+| <code>.site-tree-item-self</code> | Hook |
+| <code>.site-tree-item-text</code> | Hook |
+
+## Page header, hero, and rendered content
+
+Page identity, hero content, Markdown body, code controls, images, and task-list hooks.
+
+**DOM shape**
+
+```text
+.page-hero
+└─ .page-hero-container
+main
+├─ .page-header
+│  ├─ .page-header-title
+│  ├─ .page-header-description
+│  └─ .page-header-metadata-container
+└─ .rendered-mdx
+```
+
+| Class | Kind |
+| --- | --- |
+| <code>.contains-task-list</code> | Hook |
+| <code>.heading-link</code> | Hook |
+| <code>.image-full</code> | Hook |
+| <code>.page-header</code> | Hook |
+| <code>.page-header-author-avatar</code> | Hook |
+| <code>.page-header-author-name</code> | Hook |
+| <code>.page-header-authors-avatars-container</code> | Hook |
+| <code>.page-header-authors-container</code> | Hook |
+| <code>.page-header-date</code> | Hook |
+| <code>.page-header-date-icon</code> | Hook |
+| <code>.page-header-description</code> | Hook |
+| <code>.page-header-image</code> | Hook |
+| <code>.page-header-image-container</code> | Hook |
+| <code>.page-header-metadata-container</code> | Hook |
+| <code>.page-header-title</code> | Hook |
+| <code>.page-hero</code> | Hook |
+| <code>.page-hero-container</code> | Hook |
+| <code>.page-hero-content</code> | Hook |
+| <code>.page-hero-content-container</code> | Hook |
+| <code>.page-hero-cta</code> | Hook |
+| <code>.page-hero-ctas-container</code> | Hook |
+| <code>.page-hero-description</code> | Hook |
+| <code>.page-hero-image</code> | Hook |
+| <code>.page-hero-image-container</code> | Hook |
+| <code>.page-hero-title</code> | Hook |
+| <code>.pre-container</code> | Hook |
+| <code>.pre-copy-button</code> | Hook |
+| <code>.pre-icon</code> | Hook |
+| <code>.pre-sr</code> | Hook |
+| <code>.prose</code> | Hook |
+| <code>.rendered-mdx</code> | Hook |
+
+## Table of contents
+
+The page ToC rail and recursively nested ToC items.
+
+**DOM shape**
+
+```text
+.page-toc-container
+└─ .toc
+   ├─ .toc-title
+   └─ .toc-item
+      ├─ .toc-item-self
+      └─ .toc-item-children
+```
+
+| Class | Kind |
+| --- | --- |
+| <code>.page-toc-container</code> | Hook |
+| <code>.toc</code> | Hook |
+| <code>.toc-item</code> | Hook |
+| <code>.toc-item-children</code> | Hook |
+| <code>.toc-item-self</code> | Hook |
+| <code>.toc-title</code> | Hook |
+
+## Lists, cards, skeletons, and pagination
+
+Collection/blog listing cards, loading placeholders, and pagination controls.
+
+**DOM shape**
+
+```text
+.list-component
+├─ .list-component-item / .list-component-skeleton-item
+│  ├─ *-media
+│  └─ *-content
+└─ .list-component-pagination
+   ├─ .list-component-pagination-nav
+   └─ .list-component-pagination-pages
+```
+
+| Class | Kind |
+| --- | --- |
+| <code>.list-component</code> | Hook |
+| <code>.list-component-item</code> | Hook |
+| <code>.list-component-item-content</code> | Hook |
+| <code>.list-component-item-eyebrow</code> | Hook |
+| <code>.list-component-item-footnote</code> | Hook |
+| <code>.list-component-item-headline</code> | Hook |
+| <code>.list-component-item-media</code> | Hook |
+| <code>.list-component-item-media-img</code> | Hook |
+| <code>.list-component-item-summary</code> | Hook |
+| <code>.list-component-pagination</code> | Hook |
+| <code>.list-component-pagination-button</code> | Hook |
+| <code>.list-component-pagination-button--next</code> | Variant |
+| <code>.list-component-pagination-button--prev</code> | Variant |
+| <code>.list-component-pagination-button-icon</code> | Hook |
+| <code>.list-component-pagination-button-icon--next</code> | Variant |
+| <code>.list-component-pagination-button-icon--prev</code> | Variant |
+| <code>.list-component-pagination-ellipsis</code> | Hook |
+| <code>.list-component-pagination-nav</code> | Hook |
+| <code>.list-component-pagination-nav--end</code> | Variant |
+| <code>.list-component-pagination-page-button</code> | Hook |
+| <code>.list-component-pagination-page-button--current</code> | Variant |
+| <code>.list-component-pagination-page-button--other</code> | Variant |
+| <code>.list-component-pagination-pages</code> | Hook |
+| <code>.list-component-skeleton</code> | Hook |
+| <code>.list-component-skeleton-content</code> | Hook |
+| <code>.list-component-skeleton-eyebrow</code> | Hook |
+| <code>.list-component-skeleton-footnote</code> | Hook |
+| <code>.list-component-skeleton-headline</code> | Hook |
+| <code>.list-component-skeleton-item</code> | Hook |
+| <code>.list-component-skeleton-media</code> | Hook |
+| <code>.list-component-skeleton-media-placeholder</code> | Hook |
+| <code>.list-component-skeleton-summary</code> | Hook |
+
+## Search button and modal
+
+Search launch control, modal shell, result states, and hit content.
+
+**DOM shape**
+
+```text
+.search-button
+.search-modal
+├─ .search-modal-backdrop
+└─ .search-modal-card-container
+   └─ .search-modal-card
+      ├─ .search-modal-input-container
+      └─ .search-modal-results
+```
+
+| Class | Kind |
+| --- | --- |
+| <code>.search-button</code> | Hook |
+| <code>.search-icon</code> | Hook |
+| <code>.search-modal</code> | Hook |
+| <code>.search-modal-backdrop</code> | Hook |
+| <code>.search-modal-card</code> | Hook |
+| <code>.search-modal-card-container</code> | Hook |
+| <code>.search-modal-close-button</code> | Hook |
+| <code>.search-modal-close-icon</code> | Hook |
+| <code>.search-modal-error-icon</code> | Hook |
+| <code>.search-modal-error-icon-text</code> | Hook |
+| <code>.search-modal-highlight</code> | Hook |
+| <code>.search-modal-hit-content</code> | Hook |
+| <code>.search-modal-hit-link</code> | Hook |
+| <code>.search-modal-hit-title</code> | Hook |
+| <code>.search-modal-hits-item</code> | Hook |
+| <code>.search-modal-hits-list</code> | Hook |
+| <code>.search-modal-input</code> | Hook |
+| <code>.search-modal-input-container</code> | Hook |
+| <code>.search-modal-loading-spinner</code> | Hook |
+| <code>.search-modal-results</code> | Hook |
+| <code>.search-modal-results-container</code> | Hook |
+| <code>.search-modal-stalled-spinner</code> | Hook |
+| <code>.search-modal-status-container</code> | Hook |
+| <code>.search-modal-status-content</code> | Hook |
+| <code>.search-modal-status-icon</code> | Hook |
+| <code>.search-modal-status-message</code> | Hook |
+| <code>.search-modal-status-submessage</code> | Hook |
+| <code>.search-placeholder</code> | Hook |
+| <code>.search-shortcut-hint</code> | Hook |
+
+## Footer
+
+Publication identity, navigation groups, social links, and copyright.
+
+**DOM shape**
+
+```text
+.site-footer
+└─ .site-footer-inner
+   └─ .site-footer-content-grid
+      ├─ .site-footer-publication-section
+      └─ .site-footer-navigation-section
+```
+
+| Class | Kind |
+| --- | --- |
+| <code>.site-footer</code> | Hook |
+| <code>.site-footer-content-grid</code> | Hook |
+| <code>.site-footer-copyright</code> | Hook |
+| <code>.site-footer-inner</code> | Hook |
+| <code>.site-footer-navigation-grid</code> | Hook |
+| <code>.site-footer-navigation-group</code> | Hook |
+| <code>.site-footer-navigation-link</code> | Hook |
+| <code>.site-footer-navigation-list</code> | Hook |
+| <code>.site-footer-navigation-section</code> | Hook |
+| <code>.site-footer-navigation-title</code> | Hook |
+| <code>.site-footer-publication-name</code> | Hook |
+| <code>.site-footer-publication-section</code> | Hook |
+| <code>.site-footer-social-icon</code> | Hook |
+| <code>.site-footer-social-link</code> | Hook |
+| <code>.site-footer-social-links</code> | Hook |
+
+## Backlinks, edit controls, and comments
+
+Blocks rendered after the main page content.
+
+**DOM shape**
+
+```text
+main
+├─ .page-edit-button-container
+├─ .page-backlinks-container
+│  └─ .page-backlinks-list
+└─ .page-comments-container
+```
+
+| Class | Kind |
+| --- | --- |
+| <code>.page-backlinks-container</code> | Hook |
+| <code>.page-backlinks-item</code> | Hook |
+| <code>.page-backlinks-list</code> | Hook |
+| <code>.page-backlinks-title</code> | Hook |
+| <code>.page-comments-container</code> | Hook |
+| <code>.page-edit-button</code> | Hook |
+| <code>.page-edit-button-container</code> | Hook |
+
+## Graph, canvas, PDF, and media embeds
+
+Graph panels/modals and document/media rendering surfaces.
+
+**DOM shape**
+
+```text
+.graph-mini-panel / .graph-modal
+.canvas-node-content
+.pdf-viewer
+├─ .pdf-header
+└─ .pdf-scroll-area
+   └─ .pdf-page
+```
+
+| Class | Kind |
+| --- | --- |
+| <code>.canvas-node-content</code> | Hook |
+| <code>.graph-mini-panel</code> | Hook |
+| <code>.graph-mini-panel__action-btn</code> | Element |
+| <code>.graph-mini-panel__actions</code> | Element |
+| <code>.graph-mini-panel__label</code> | Element |
+| <code>.graph-mini-panel--loading</code> | Variant |
+| <code>.graph-modal</code> | Hook |
+| <code>.graph-modal__close</code> | Element |
+| <code>.graph-modal__header</code> | Element |
+| <code>.graph-modal__inner</code> | Element |
+| <code>.graph-modal__title</code> | Element |
+| <code>.pdf-error</code> | Hook |
+| <code>.pdf-filename</code> | Hook |
+| <code>.pdf-header</code> | Hook |
+| <code>.pdf-loading</code> | Hook |
+| <code>.pdf-page</code> | Hook |
+| <code>.pdf-page-count</code> | Hook |
+| <code>.pdf-scroll-area</code> | Hook |
+| <code>.pdf-viewer</code> | Hook |
+
+## Error and not-found pages
+
+Public error cards, diagnostic stacks, and 404 presentation.
+
+**DOM shape**
+
+```text
+.error-page / .not-found
+└─ *-inner
+   ├─ *-title
+   ├─ *-subtitle
+   └─ *-description
+```
+
+| Class | Kind |
+| --- | --- |
+| <code>.error-card</code> | Hook |
+| <code>.error-card-icon</code> | Hook |
+| <code>.error-card-link</code> | Hook |
+| <code>.error-card-message</code> | Hook |
+| <code>.error-card-stack</code> | Hook |
+| <code>.error-card-title</code> | Hook |
+| <code>.error-page</code> | Hook |
+| <code>.error-page-description</code> | Hook |
+| <code>.error-page-inner</code> | Hook |
+| <code>.error-page-subtitle</code> | Hook |
+| <code>.error-page-title</code> | Hook |
+| <code>.not-found</code> | Hook |
+| <code>.not-found-description</code> | Hook |
+| <code>.not-found-hint</code> | Hook |
+| <code>.not-found-inner</code> | Hook |
+| <code>.not-found-subtitle</code> | Hook |
+| <code>.not-found-title</code> | Hook |
+
+## Shared states and utility hooks
+
+Cross-component presence, open/current, scrolling, image, and layout state classes.
+
+**DOM shape**
+
+```text
+Owning component
+└─ .is-* / .has-* / .no-* / shared utility hook
+```
+
+| Class | Kind |
+| --- | --- |
+| <code>.has-image</code> | State |
+| <code>.has-sidebar</code> | State |
+| <code>.has-sidebar-and-toc</code> | State |
+| <code>.has-toc</code> | State |
+| <code>.is-collapsible</code> | State |
+| <code>.is-current</code> | State |
+| <code>.is-open</code> | State |
+| <code>.is-plain</code> | State |
+| <code>.is-scrolled</code> | State |
+| <code>.no-nav</code> | State |
+| <code>.overflow-hidden</code> | Hook |
+
+---
+
+Generated by `node scripts/theme-class-reference.mjs --write`. Run
+`pnpm docs:theme-classes:check` to verify that this page matches the current
+stylesheet.

--- a/docs/plans/2026-08-21-theme-class-reference-implementation.md
+++ b/docs/plans/2026-08-21-theme-class-reference-implementation.md
@@ -1,0 +1,89 @@
+# Semantic Theme Class Reference Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish every class exposed by `default-theme.css` in a grouped reference and fail CI when the reference drifts.
+
+**Architecture:** A dependency-free Node module extracts class selectors, assigns them to documented UI areas, and generates the public Markdown reference from stable group metadata plus the current CSS. Node's built-in test runner covers extraction, classification, generation, and check-mode behavior; the root lint command runs generator check mode before Turbo.
+
+**Tech Stack:** Node.js ESM, `node:test`, Markdown, pnpm/Turbo
+
+## Global Constraints
+
+- Document the current class surface without changing `default-theme.css`.
+- Include state and variant classes and distinguish them from component roots.
+- Provide DOM/ownership sketches by area and clearly state the stability contract.
+- Generate the exhaustive appendix; do not maintain a hand-copied class list.
+- Keep L4 layout configuration out of scope.
+- Preserve `content/flowershow-app/docs/reference/themes.md` unchanged.
+
+---
+
+### Task 1: Build the tested class extractor and classifier
+
+**Files:**
+- Create: `scripts/theme-class-reference.mjs`
+- Create: `scripts/theme-class-reference.test.mjs`
+
+**Interfaces:**
+- Produces: `extractClassNames(css: string): string[]`
+- Produces: `classifyClassName(name: string): string`
+- Produces: `generateReference(css: string): string`
+
+- [ ] Write tests showing that extraction strips comments/strings, ignores decimal and URL fragments, deduplicates, and sorts class names.
+- [ ] Run `node --test scripts/theme-class-reference.test.mjs` and observe failure because the module is missing.
+- [ ] Implement the minimal extractor and classifier with explicit group metadata.
+- [ ] Add generation tests asserting frontmatter, stability language, structural sketches, all fixture classes exactly once, and state/variant labeling.
+- [ ] Run the test file until all cases pass.
+- [ ] Commit with `git commit -m "feat(docs): generate semantic theme class reference"`.
+
+### Task 2: Generate the public reference and check mode
+
+**Files:**
+- Modify: `scripts/theme-class-reference.mjs`
+- Modify: `scripts/theme-class-reference.test.mjs`
+- Create: `content/flowershow-app/docs/reference/theme-class-reference.md`
+
+**Interfaces:**
+- CLI: `node scripts/theme-class-reference.mjs --write`
+- CLI: `node scripts/theme-class-reference.mjs --check`
+
+- [ ] Add a failing test proving `--check` exits non-zero when output differs and succeeds after `--write`.
+- [ ] Implement CLI path resolution from repository root, deterministic output, write mode, and diff-style check failure text.
+- [ ] Run `node scripts/theme-class-reference.mjs --write` against the real stylesheet.
+- [ ] Run `node scripts/theme-class-reference.mjs --check` and the unit tests.
+- [ ] Confirm every extracted class occurs in the generated reference and the generated class count matches extraction.
+- [ ] Commit with `git commit -m "docs: publish semantic theme class reference"`.
+
+### Task 3: Enforce drift checking and make the page discoverable
+
+**Files:**
+- Modify: `package.json`
+- Modify: `content/flowershow-app/docs/reference/custom-styles.md`
+- Do not modify: `content/flowershow-app/docs/reference/themes.md`
+
+**Interfaces:**
+- Produces: `pnpm docs:theme-classes`
+- Produces: `pnpm docs:theme-classes:check`
+- Extends: root `pnpm lint`
+
+- [ ] Add scripts for write/check and prepend the check to root lint.
+- [ ] Add a prominent link from custom-styles documentation explaining when authors need the semantic class reference rather than tokens.
+- [ ] Prove the themes reference has no diff with `git diff --exit-code main -- content/flowershow-app/docs/reference/themes.md`.
+- [ ] Run `pnpm docs:theme-classes:check`, `pnpm lint`, and `pnpm test`.
+- [ ] Commit with `git commit -m "ci: check theme class reference drift"`.
+
+### Task 4: Review, publish, and close #1338
+
+**Files:**
+- No new implementation files
+
+**Interfaces:**
+- Produces: merged `flowershow/flowershow` PR and closed #1338
+
+- [ ] Run independent review over `main..HEAD` and resolve all Critical/Important findings.
+- [ ] Run fresh unit, generator-check, lint, test, and diff verification.
+- [ ] Push `docs/theme-class-reference` and open a non-draft PR linking #1338 and #1364.
+- [ ] Await required checks, merge normally, update local `main`, and rerun generator check.
+- [ ] Close #1338 with the merged PR and public documentation path.
+- [ ] Update #1364 to mark the semantic-class acceptance item complete.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev:down": "docker compose --profile stripe --profile github --profile search down",
     "dev:nuke": "docker compose --profile stripe --profile github --profile search down -v",
     "lint": "pnpm docs:theme-classes:check && turbo run lint",
-    "test": "turbo run test",
+    "test": "node --test scripts/theme-class-reference.test.mjs && turbo run test",
     "format": "biome format .",
     "format:write": "biome format --write .",
     "changeset": "changeset",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev:local:all": "bash scripts/dev-local.sh --all",
     "dev:down": "docker compose --profile stripe --profile github --profile search down",
     "dev:nuke": "docker compose --profile stripe --profile github --profile search down -v",
-    "lint": "turbo run lint",
+    "lint": "pnpm docs:theme-classes:check && turbo run lint",
     "test": "turbo run test",
     "format": "biome format .",
     "format:write": "biome format --write .",
@@ -17,6 +17,8 @@
     "version-packages": "changeset version",
     "release": "turbo run build --filter=./packages/... && changeset publish",
     "docs:sitemap": "tsx scripts/generate-docs-sitemap.ts",
+    "docs:theme-classes": "node scripts/theme-class-reference.mjs --write",
+    "docs:theme-classes:check": "node scripts/theme-class-reference.mjs --check",
     "prepare": "husky install"
   },
   "devDependencies": {

--- a/scripts/theme-class-reference.mjs
+++ b/scripts/theme-class-reference.mjs
@@ -8,28 +8,28 @@ const GROUPS = [
     id: 'layout',
     title: 'Site layout and page shell',
     description: 'Top-level site grid, responsive rails, and shell variants.',
-    dom: `.site-layout[.no-nav]\n└─ .layout-inner[.has-sidebar][.has-toc]\n   ├─ .layout-inner-left\n   ├─ main\n   └─ .layout-inner-right`,
+    dom: `.site-layout[.no-nav]\n├─ .site-navbar (optional)\n├─ .site-body (structural wrapper)\n│  ├─ .site-subnav (optional)\n│  ├─ .page-hero-container (optional)\n│  └─ .layout-inner[.has-sidebar | .has-toc | .has-sidebar-and-toc]\n│     ├─ .layout-inner-left\n│     ├─ .layout-inner-center (structural wrapper)\n│     │  └─ main.page-main (structural wrapper)\n│     └─ .layout-inner-right\n└─ .site-footer`,
   },
   {
     id: 'navigation',
     title: 'Navbar and mobile navigation',
     description:
       'Desktop navbar, dropdowns, mobile navigation, theme switch, and visitor controls.',
-    dom: `.site-navbar\n└─ .site-navbar-inner\n   ├─ .site-navbar-site-name\n   ├─ .site-navbar-links-container\n   │  ├─ .site-navbar-link\n   │  └─ .site-navbar-dropdown\n   └─ .site-navbar-mobile-nav-button\n      └─ .mobile-nav`,
+    dom: `.site-navbar\n├─ .site-navbar-inner\n│  ├─ .site-navbar-site-name\n│  ├─ .site-navbar-links-container\n│  │  ├─ .site-navbar-link\n│  │  └─ .site-navbar-dropdown\n│  └─ .site-navbar-mobile-nav-button\n└─ .mobile-nav`,
   },
   {
     id: 'sidebar',
     title: 'Subnavigation, sidebar, and site tree',
     description:
       'Breadcrumbs, desktop site tree, and the small-screen sidebar drawer.',
-    dom: `.site-subnav\n├─ .site-subnav-breadcrumbs\n└─ .site-subnav-menu-button\n.site-sidebar / .sidebar-drawer-panel\n└─ .site-tree\n   └─ .site-tree-item\n      ├─ .site-tree-item-self\n      └─ .site-tree-item-children`,
+    dom: `.site-subnav\n├─ .site-subnav-breadcrumbs\n└─ .site-subnav-menu-button\n.layout-inner-left\n└─ .site-sidebar\n   └─ .site-tree\nbody (dialog portal)\n└─ .sidebar-drawer-panel\n   └─ .site-tree`,
   },
   {
     id: 'content',
     title: 'Page header, hero, and rendered content',
     description:
       'Page identity, hero content, Markdown body, code controls, images, and task-list hooks.',
-    dom: `.page-hero\n└─ .page-hero-container\nmain\n├─ .page-header\n│  ├─ .page-header-title\n│  ├─ .page-header-description\n│  └─ .page-header-metadata-container\n└─ .rendered-mdx`,
+    dom: `.page-hero-container\n└─ .page-hero[.has-image]\nmain.page-main (structural wrapper)\n├─ .page-header\n│  ├─ .page-header-title\n│  ├─ .page-header-description\n│  └─ .page-header-metadata-container\n└─ .page-body (structural wrapper)\n   └─ .rendered-mdx[.is-plain]`,
   },
   {
     id: 'toc',
@@ -62,7 +62,7 @@ const GROUPS = [
     id: 'page-actions',
     title: 'Backlinks, edit controls, and comments',
     description: 'Blocks rendered after the main page content.',
-    dom: `main\n├─ .page-edit-button-container\n├─ .page-backlinks-container\n│  └─ .page-backlinks-list\n└─ .page-comments-container`,
+    dom: `.layout-inner-center (structural wrapper)\n├─ main.page-main (structural wrapper)\n├─ .page-edit-button-container\n├─ .page-backlinks-container\n│  └─ .page-backlinks-list\n└─ .page-comments-container`,
   },
   {
     id: 'embeds',
@@ -78,12 +78,35 @@ const GROUPS = [
   },
   {
     id: 'states',
-    title: 'Shared states and utility hooks',
+    title: 'Shared states',
     description:
-      'Cross-component presence, open/current, scrolling, image, and layout state classes.',
-    dom: `Owning component\n└─ .is-* / .has-* / .no-* / shared utility hook`,
+      'Conditional presence, open/current, image, and layout states.',
+    dom: `Owning semantic hook\n└─ .is-* / .has-* / .no-*`,
+  },
+  {
+    id: 'compatibility',
+    title: 'Compatibility utilities (not public API)',
+    description:
+      'Selectors retained for exhaustive drift tracking but excluded from the semantic theme-author contract.',
+    sketchTitle: 'CSS layer',
+    dom: `@layer utilities\n├─ .prose\n└─ .overflow-hidden`,
   },
 ];
+
+const COMPATIBILITY_CLASSES = new Set(['overflow-hidden', 'prose']);
+
+const STATE_OWNERS = {
+  'has-image': '.page-hero',
+  'has-sidebar': '.layout-inner',
+  'has-sidebar-and-toc': '.layout-inner',
+  'has-toc': '.layout-inner',
+  'is-collapsible': '.site-tree-item-self / .mobile-nav-tree-item-self',
+  'is-current': '.site-tree-item-self / .mobile-nav-tree-item-self',
+  'is-open': 'navigation dropdowns and collapsible tree items',
+  'is-plain': '.rendered-mdx',
+  'is-scrolled': '.site-navbar',
+  'no-nav': '.site-layout',
+};
 
 export function extractClassNames(css) {
   const scrubbed = css
@@ -97,7 +120,8 @@ export function extractClassNames(css) {
 }
 
 export function classifyClassName(name) {
-  if (/^(is-|has-|no-nav$|overflow-hidden$)/.test(name)) return 'states';
+  if (COMPATIBILITY_CLASSES.has(name)) return 'compatibility';
+  if (/^(is-|has-|no-nav$)/.test(name)) return 'states';
   if (/^(site-layout|layout-)/.test(name)) return 'layout';
   if (/^(site-navbar|mobile-nav|theme-switch|visitor-logout)/.test(name))
     return 'navigation';
@@ -121,6 +145,7 @@ export function classifyClassName(name) {
 }
 
 function classKind(name) {
+  if (COMPATIBILITY_CLASSES.has(name)) return 'Compatibility';
   if (/^(is-|has-|no-)/.test(name)) return 'State';
   if (name.includes('--')) return 'Variant';
   if (name.includes('__')) return 'Element';
@@ -129,6 +154,10 @@ function classKind(name) {
 
 export function generateReference(css) {
   const classNames = extractClassNames(css);
+  const compatibilityCount = classNames.filter((className) =>
+    COMPATIBILITY_CLASSES.has(className),
+  ).length;
+  const semanticCount = classNames.length - compatibilityCount;
   const grouped = new Map(GROUPS.map((group) => [group.id, []]));
   for (const className of classNames) {
     const group = classifyClassName(className);
@@ -141,14 +170,19 @@ export function generateReference(css) {
   const sections = GROUPS.filter(
     (group) => grouped.get(group.id).length > 0,
   ).map((group) => {
+    const isStateGroup = group.id === 'states';
     const rows = grouped
       .get(group.id)
-      .map(
-        (className) =>
-          `| <code>.${className}</code> | ${classKind(className)} |`,
-      )
+      .map((className) => {
+        if (isStateGroup) {
+          return `| <code>.${className}</code> | ${classKind(className)} | ${STATE_OWNERS[className]} |`;
+        }
+        return `| <code>.${className}</code> | ${classKind(className)} |`;
+      })
       .join('\n');
-    return `## ${group.title}\n\n${group.description}\n\n**DOM shape**\n\n\`\`\`text\n${group.dom}\n\`\`\`\n\n| Class | Kind |\n| --- | --- |\n${rows}`;
+    const ownerHeader = isStateGroup ? ' Owner |' : '';
+    const ownerDivider = isStateGroup ? ' --- |' : '';
+    return `## ${group.title}\n\n${group.description}\n\n**${group.sketchTitle ?? 'DOM shape'}**\n\n\`\`\`text\n${group.dom}\n\`\`\`\n\n| Class | Kind |${ownerHeader}\n| --- | --- |${ownerDivider}\n${rows}`;
   });
 
   return `---
@@ -160,20 +194,29 @@ Flowershow themes start with [custom properties](/docs/reference/custom-styles),
 then use semantic classes when a component needs more specific treatment. This
 page is generated from
 [\`default-theme.css\`](https://github.com/flowershow/flowershow/blob/main/apps/flowershow/styles/default-theme.css)
-and currently documents **${classNames.length} unique class hooks**.
+and currently documents **${classNames.length} styled class selectors**:
+**${semanticCount} stable semantic hooks** and **${compatibilityCount} non-contract
+compatibility utilities**.
 
 ## Stability contract
 
-The component and element hooks listed here are a public theme-author API.
+The semantic component, element, state, and variant hooks listed here are a
+public theme-author API.
 Removing or renaming one, or changing what UI element it represents, is a
 breaking change for themes. Adding a hook is non-breaking. State and Variant
 hooks are stable in name but only appear when their owning component enters
 that state; do not assume every page renders every hook.
 
-The list is exhaustive for classes styled by \`default-theme.css\`. Raw utility
-classes used only inside component source are not an authoring contract unless
-they also appear here. Structure is still controlled by Flowershow core: these
-hooks change presentation, not which components render or their order.
+The list is exhaustive for classes styled by \`default-theme.css\`. The final
+compatibility section is drift-checked but explicitly excluded from the public
+API. Emitted-only class names and raw utility classes used inside component
+source are not an authoring contract unless they appear in a semantic table on
+this page.
+
+Structural wrappers shown in DOM sketches but absent from their accompanying
+tables provide nesting context only; they are not stable hooks. Structure is
+still controlled by Flowershow core: these hooks change presentation, not which
+components render or their order.
 
 Kinds used below:
 
@@ -181,6 +224,7 @@ Kinds used below:
 - **Element** — BEM-style child written with \`__\`.
 - **Variant** — alternative treatment written with \`--\`.
 - **State** — conditional \`is-*\`, \`has-*\`, or \`no-*\` hook.
+- **Compatibility** — styled utility retained for compatibility, not public API.
 
 ## Related non-class hooks
 

--- a/scripts/theme-class-reference.mjs
+++ b/scripts/theme-class-reference.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const GROUPS = [
+  {
+    id: 'layout',
+    title: 'Site layout and page shell',
+    description: 'Top-level site grid, responsive rails, and shell variants.',
+    dom: `.site-layout[.no-nav]\n└─ .layout-inner[.has-sidebar][.has-toc]\n   ├─ .layout-inner-left\n   ├─ main\n   └─ .layout-inner-right`,
+  },
+  {
+    id: 'navigation',
+    title: 'Navbar and mobile navigation',
+    description:
+      'Desktop navbar, dropdowns, mobile navigation, theme switch, and visitor controls.',
+    dom: `.site-navbar\n└─ .site-navbar-inner\n   ├─ .site-navbar-site-name\n   ├─ .site-navbar-links-container\n   │  ├─ .site-navbar-link\n   │  └─ .site-navbar-dropdown\n   └─ .site-navbar-mobile-nav-button\n      └─ .mobile-nav`,
+  },
+  {
+    id: 'sidebar',
+    title: 'Subnavigation, sidebar, and site tree',
+    description:
+      'Breadcrumbs, desktop site tree, and the small-screen sidebar drawer.',
+    dom: `.site-subnav\n├─ .site-subnav-breadcrumbs\n└─ .site-subnav-menu-button\n.site-sidebar / .sidebar-drawer-panel\n└─ .site-tree\n   └─ .site-tree-item\n      ├─ .site-tree-item-self\n      └─ .site-tree-item-children`,
+  },
+  {
+    id: 'content',
+    title: 'Page header, hero, and rendered content',
+    description:
+      'Page identity, hero content, Markdown body, code controls, images, and task-list hooks.',
+    dom: `.page-hero\n└─ .page-hero-container\nmain\n├─ .page-header\n│  ├─ .page-header-title\n│  ├─ .page-header-description\n│  └─ .page-header-metadata-container\n└─ .rendered-mdx`,
+  },
+  {
+    id: 'toc',
+    title: 'Table of contents',
+    description: 'The page ToC rail and recursively nested ToC items.',
+    dom: `.page-toc-container\n└─ .toc\n   ├─ .toc-title\n   └─ .toc-item\n      ├─ .toc-item-self\n      └─ .toc-item-children`,
+  },
+  {
+    id: 'listings',
+    title: 'Lists, cards, skeletons, and pagination',
+    description:
+      'Collection/blog listing cards, loading placeholders, and pagination controls.',
+    dom: `.list-component\n├─ .list-component-item / .list-component-skeleton-item\n│  ├─ *-media\n│  └─ *-content\n└─ .list-component-pagination\n   ├─ .list-component-pagination-nav\n   └─ .list-component-pagination-pages`,
+  },
+  {
+    id: 'search',
+    title: 'Search button and modal',
+    description:
+      'Search launch control, modal shell, result states, and hit content.',
+    dom: `.search-button\n.search-modal\n├─ .search-modal-backdrop\n└─ .search-modal-card-container\n   └─ .search-modal-card\n      ├─ .search-modal-input-container\n      └─ .search-modal-results`,
+  },
+  {
+    id: 'footer',
+    title: 'Footer',
+    description:
+      'Publication identity, navigation groups, social links, and copyright.',
+    dom: `.site-footer\n└─ .site-footer-inner\n   └─ .site-footer-content-grid\n      ├─ .site-footer-publication-section\n      └─ .site-footer-navigation-section`,
+  },
+  {
+    id: 'page-actions',
+    title: 'Backlinks, edit controls, and comments',
+    description: 'Blocks rendered after the main page content.',
+    dom: `main\n├─ .page-edit-button-container\n├─ .page-backlinks-container\n│  └─ .page-backlinks-list\n└─ .page-comments-container`,
+  },
+  {
+    id: 'embeds',
+    title: 'Graph, canvas, PDF, and media embeds',
+    description: 'Graph panels/modals and document/media rendering surfaces.',
+    dom: `.graph-mini-panel / .graph-modal\n.canvas-node-content\n.pdf-viewer\n├─ .pdf-header\n└─ .pdf-scroll-area\n   └─ .pdf-page`,
+  },
+  {
+    id: 'errors',
+    title: 'Error and not-found pages',
+    description: 'Public error cards, diagnostic stacks, and 404 presentation.',
+    dom: `.error-page / .not-found\n└─ *-inner\n   ├─ *-title\n   ├─ *-subtitle\n   └─ *-description`,
+  },
+  {
+    id: 'states',
+    title: 'Shared states and utility hooks',
+    description:
+      'Cross-component presence, open/current, scrolling, image, and layout state classes.',
+    dom: `Owning component\n└─ .is-* / .has-* / .no-* / shared utility hook`,
+  },
+];
+
+export function extractClassNames(css) {
+  const scrubbed = css
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/url\((?:\\.|[^)])*\)/gi, ' ')
+    .replace(/"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'/g, ' ');
+  const names = [...scrubbed.matchAll(/\.([A-Za-z_][A-Za-z0-9_-]*)\b/g)].map(
+    (match) => match[1],
+  );
+  return [...new Set(names)].sort((left, right) => left.localeCompare(right));
+}
+
+export function classifyClassName(name) {
+  if (/^(is-|has-|no-nav$|overflow-hidden$)/.test(name)) return 'states';
+  if (/^(site-layout|layout-)/.test(name)) return 'layout';
+  if (/^(site-navbar|mobile-nav|theme-switch|visitor-logout)/.test(name))
+    return 'navigation';
+  if (/^(site-subnav|site-tree|site-sidebar|sidebar-drawer)/.test(name))
+    return 'sidebar';
+  if (/^(page-toc|toc(?:-|$))/.test(name)) return 'toc';
+  if (/^list-component/.test(name)) return 'listings';
+  if (/^search/.test(name)) return 'search';
+  if (/^site-footer/.test(name)) return 'footer';
+  if (/^page-(backlinks|comments|edit)/.test(name)) return 'page-actions';
+  if (/^(graph-|pdf-|canvas-)/.test(name)) return 'embeds';
+  if (/^(error-|not-found)/.test(name)) return 'errors';
+  if (
+    /^(page-(header|hero)|rendered-mdx|heading-link|pre-|prose$|contains-task-list|image-full)/.test(
+      name,
+    )
+  ) {
+    return 'content';
+  }
+  return 'unclassified';
+}
+
+function classKind(name) {
+  if (/^(is-|has-|no-)/.test(name)) return 'State';
+  if (name.includes('--')) return 'Variant';
+  if (name.includes('__')) return 'Element';
+  return 'Hook';
+}
+
+export function generateReference(css) {
+  const classNames = extractClassNames(css);
+  const grouped = new Map(GROUPS.map((group) => [group.id, []]));
+  for (const className of classNames) {
+    const group = classifyClassName(className);
+    if (!grouped.has(group)) {
+      throw new Error(`Unclassified theme class: .${className}`);
+    }
+    grouped.get(group).push(className);
+  }
+
+  const sections = GROUPS.filter(
+    (group) => grouped.get(group.id).length > 0,
+  ).map((group) => {
+    const rows = grouped
+      .get(group.id)
+      .map(
+        (className) =>
+          `| <code>.${className}</code> | ${classKind(className)} |`,
+      )
+      .join('\n');
+    return `## ${group.title}\n\n${group.description}\n\n**DOM shape**\n\n\`\`\`text\n${group.dom}\n\`\`\`\n\n| Class | Kind |\n| --- | --- |\n${rows}`;
+  });
+
+  return `---
+title: Semantic theme class reference
+description: Stable Flowershow CSS hooks grouped by the UI areas that emit them.
+---
+
+Flowershow themes start with [custom properties](/docs/reference/custom-styles),
+then use semantic classes when a component needs more specific treatment. This
+page is generated from
+[\`default-theme.css\`](https://github.com/flowershow/flowershow/blob/main/apps/flowershow/styles/default-theme.css)
+and currently documents **${classNames.length} unique class hooks**.
+
+## Stability contract
+
+The component and element hooks listed here are a public theme-author API.
+Removing or renaming one, or changing what UI element it represents, is a
+breaking change for themes. Adding a hook is non-breaking. State and Variant
+hooks are stable in name but only appear when their owning component enters
+that state; do not assume every page renders every hook.
+
+The list is exhaustive for classes styled by \`default-theme.css\`. Raw utility
+classes used only inside component source are not an authoring contract unless
+they also appear here. Structure is still controlled by Flowershow core: these
+hooks change presentation, not which components render or their order.
+
+Kinds used below:
+
+- **Hook** — component or semantic element.
+- **Element** — BEM-style child written with \`__\`.
+- **Variant** — alternative treatment written with \`--\`.
+- **State** — conditional \`is-*\`, \`has-*\`, or \`no-*\` hook.
+
+## Related non-class hooks
+
+Callouts use data attributes rather than classes:
+
+- \`[data-callout]\`
+- \`[data-callout-type="note"]\` (and other callout types)
+- \`[data-callout-title]\`
+- \`[data-callout-body]\`
+
+Scope callout overrides below \`.rendered-mdx\` so they outrank the base
+attribute selectors without relying on source order.
+
+${sections.join('\n\n')}
+
+---
+
+Generated by \`node scripts/theme-class-reference.mjs --write\`. Run
+\`pnpm docs:theme-classes:check\` to verify that this page matches the current
+stylesheet.
+`;
+}
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const defaultPaths = {
+  cssPath: resolve(repositoryRoot, 'apps/flowershow/styles/default-theme.css'),
+  outputPath: resolve(
+    repositoryRoot,
+    'content/flowershow-app/docs/reference/theme-class-reference.md',
+  ),
+};
+
+export async function runCli(args, options = {}) {
+  const cssPath = options.cssPath ?? defaultPaths.cssPath;
+  const outputPath = options.outputPath ?? defaultPaths.outputPath;
+  const log = options.log ?? console.log;
+  const error = options.error ?? console.error;
+  const mode = args[0];
+
+  if (mode !== '--write' && mode !== '--check') {
+    error('Usage: node scripts/theme-class-reference.mjs --write|--check');
+    return 2;
+  }
+
+  const css = await readFile(cssPath, 'utf8');
+  const expected = generateReference(css);
+
+  if (mode === '--write') {
+    await mkdir(dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, expected);
+    log(`Wrote ${outputPath}`);
+    return 0;
+  }
+
+  let actual = '';
+  try {
+    actual = await readFile(outputPath, 'utf8');
+  } catch (readError) {
+    if (readError.code !== 'ENOENT') throw readError;
+  }
+
+  if (actual !== expected) {
+    error(
+      `Theme class reference is out of date: ${outputPath}\nRun: pnpm docs:theme-classes`,
+    );
+    return 1;
+  }
+
+  log(
+    `Theme class reference is current (${extractClassNames(css).length} classes).`,
+  );
+  return 0;
+}
+
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  process.exitCode = await runCli(process.argv.slice(2));
+}

--- a/scripts/theme-class-reference.mjs
+++ b/scripts/theme-class-reference.mjs
@@ -29,7 +29,7 @@ const GROUPS = [
     title: 'Page header, hero, and rendered content',
     description:
       'Page identity, hero content, Markdown body, code controls, images, and task-list hooks.',
-    dom: `.page-hero-container\n└─ .page-hero[.has-image]\nmain.page-main (structural wrapper)\n├─ .page-header\n│  ├─ .page-header-title\n│  ├─ .page-header-description\n│  └─ .page-header-metadata-container\n└─ .page-body (structural wrapper)\n   └─ .rendered-mdx[.is-plain]`,
+    dom: `.page-hero-container\n└─ .page-hero[.has-image | .image-full]\nmain.page-main (structural wrapper)\n├─ .page-header\n│  ├─ .page-header-title\n│  ├─ .page-header-description\n│  └─ .page-header-metadata-container\n└─ .page-body (structural wrapper)\n   └─ .rendered-mdx[.is-plain]`,
   },
   {
     id: 'toc',
@@ -78,10 +78,10 @@ const GROUPS = [
   },
   {
     id: 'states',
-    title: 'Shared states',
+    title: 'Shared states and layout variants',
     description:
-      'Conditional presence, open/current, image, and layout states.',
-    dom: `Owning semantic hook\n└─ .is-* / .has-* / .no-*`,
+      'Conditional presence, open/current, image, and layout modifiers.',
+    dom: `Owning semantic hook\n└─ .is-* / .has-* / .no-* / .image-full`,
   },
   {
     id: 'compatibility',
@@ -97,6 +97,7 @@ const COMPATIBILITY_CLASSES = new Set(['overflow-hidden', 'prose']);
 
 const STATE_OWNERS = {
   'has-image': '.page-hero',
+  'image-full': '.page-hero',
   'has-sidebar': '.layout-inner',
   'has-sidebar-and-toc': '.layout-inner',
   'has-toc': '.layout-inner',
@@ -121,6 +122,7 @@ export function extractClassNames(css) {
 
 export function classifyClassName(name) {
   if (COMPATIBILITY_CLASSES.has(name)) return 'compatibility';
+  if (name === 'image-full') return 'states';
   if (/^(is-|has-|no-nav$)/.test(name)) return 'states';
   if (/^(site-layout|layout-)/.test(name)) return 'layout';
   if (/^(site-navbar|mobile-nav|theme-switch|visitor-logout)/.test(name))
@@ -135,7 +137,7 @@ export function classifyClassName(name) {
   if (/^(graph-|pdf-|canvas-)/.test(name)) return 'embeds';
   if (/^(error-|not-found)/.test(name)) return 'errors';
   if (
-    /^(page-(header|hero)|rendered-mdx|heading-link|pre-|prose$|contains-task-list|image-full)/.test(
+    /^(page-(header|hero)|rendered-mdx|heading-link|pre-|contains-task-list)/.test(
       name,
     )
   ) {
@@ -146,6 +148,7 @@ export function classifyClassName(name) {
 
 function classKind(name) {
   if (COMPATIBILITY_CLASSES.has(name)) return 'Compatibility';
+  if (name === 'image-full') return 'Variant';
   if (/^(is-|has-|no-)/.test(name)) return 'State';
   if (name.includes('--')) return 'Variant';
   if (name.includes('__')) return 'Element';

--- a/scripts/theme-class-reference.test.mjs
+++ b/scripts/theme-class-reference.test.mjs
@@ -48,6 +48,7 @@ test('classifyClassName assigns representative hooks to stable UI areas', () => 
   assert.equal(classifyClassName('graph-modal'), 'embeds');
   assert.equal(classifyClassName('not-found-title'), 'errors');
   assert.equal(classifyClassName('is-current'), 'states');
+  assert.equal(classifyClassName('image-full'), 'states');
   assert.equal(classifyClassName('prose'), 'compatibility');
   assert.equal(classifyClassName('overflow-hidden'), 'compatibility');
   assert.equal(classifyClassName('made-up-hook'), 'unclassified');
@@ -98,6 +99,13 @@ test('generateReference includes the real center wrapper around main', () => {
     output,
     /\.layout-inner-center \(structural wrapper\)\n│     │  └─ main\.page-main/,
   );
+});
+
+test('generateReference identifies the image-full layout variant and owner', () => {
+  const output = generateReference('.page-hero.image-full { display: grid; }');
+
+  assert.match(output, /<code>\.image-full<\/code> \| Variant \| \.page-hero/);
+  assert.match(output, /\.page-hero\[\.has-image \| \.image-full\]/);
 });
 
 test('generateReference separates utilities from the public contract and names state owners', () => {

--- a/scripts/theme-class-reference.test.mjs
+++ b/scripts/theme-class-reference.test.mjs
@@ -48,6 +48,8 @@ test('classifyClassName assigns representative hooks to stable UI areas', () => 
   assert.equal(classifyClassName('graph-modal'), 'embeds');
   assert.equal(classifyClassName('not-found-title'), 'errors');
   assert.equal(classifyClassName('is-current'), 'states');
+  assert.equal(classifyClassName('prose'), 'compatibility');
+  assert.equal(classifyClassName('overflow-hidden'), 'compatibility');
   assert.equal(classifyClassName('made-up-hook'), 'unclassified');
 });
 
@@ -69,10 +71,15 @@ test('generateReference documents structure, stability, and each class once', ()
   assert.match(output, /^---\ntitle: Semantic theme class reference/m);
   assert.match(output, /Stability contract/);
   assert.match(output, /DOM shape/);
-  assert.match(output, /5 unique class hooks/);
+  assert.match(output, /5 styled class selectors/);
+  assert.match(output, /5 stable semantic hooks/);
   assert.match(output, /State/);
   assert.match(output, /Variant/);
   assert.match(output, /Element/);
+  assert.match(
+    output,
+    /\.site-navbar\n├─ \.site-navbar-inner[\s\S]*└─ \.mobile-nav/,
+  );
 
   for (const className of extractClassNames(fixtureCss)) {
     const occurrences = output.split(`<code>.${className}</code>`).length - 1;
@@ -82,6 +89,28 @@ test('generateReference documents structure, stability, and each class once', ()
       `${className} should occur once in the tables`,
     );
   }
+});
+
+test('generateReference includes the real center wrapper around main', () => {
+  const output = generateReference('.site-layout { display: block; }');
+
+  assert.match(
+    output,
+    /\.layout-inner-center \(structural wrapper\)\n│     │  └─ main\.page-main/,
+  );
+});
+
+test('generateReference separates utilities from the public contract and names state owners', () => {
+  const output = generateReference(`
+    .site-navbar.is-scrolled { color: red; }
+    @layer utilities { .prose { color: inherit; } }
+  `);
+
+  assert.match(output, /3 styled class selectors/);
+  assert.match(output, /2 stable semantic hooks/);
+  assert.match(output, /1\s+non-contract\s+compatibility utilities/);
+  assert.match(output, /Compatibility utilities \(not public API\)/);
+  assert.match(output, /<code>\.is-scrolled<\/code> \| State \| \.site-navbar/);
 });
 
 test('runCli writes deterministic output and detects drift', async () => {

--- a/scripts/theme-class-reference.test.mjs
+++ b/scripts/theme-class-reference.test.mjs
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  classifyClassName,
+  extractClassNames,
+  generateReference,
+  runCli,
+} from './theme-class-reference.mjs';
+
+const fixtureCss = `
+/* .comment-only and https://docs.example.com/file.css */
+.site-navbar, .site-navbar.is-open > .site-navbar-link {
+  opacity: 0.5;
+  content: ".string-only";
+  background-image: url("https://cdn.example.com/image.png");
+  mask-image: url(https://cdn.example.com/icon.svg);
+}
+.list-component-pagination-button--current,
+.graph-modal__close,
+.site-navbar-link { color: red; }
+`;
+
+test('extractClassNames returns only real, unique, sorted class selectors', () => {
+  assert.deepEqual(extractClassNames(fixtureCss), [
+    'graph-modal__close',
+    'is-open',
+    'list-component-pagination-button--current',
+    'site-navbar',
+    'site-navbar-link',
+  ]);
+});
+
+test('classifyClassName assigns representative hooks to stable UI areas', () => {
+  assert.equal(classifyClassName('site-layout'), 'layout');
+  assert.equal(classifyClassName('layout-inner-left'), 'layout');
+  assert.equal(classifyClassName('site-navbar-link'), 'navigation');
+  assert.equal(classifyClassName('site-tree-item-self'), 'sidebar');
+  assert.equal(classifyClassName('page-header-title'), 'content');
+  assert.equal(classifyClassName('page-toc-container'), 'toc');
+  assert.equal(classifyClassName('list-component-item'), 'listings');
+  assert.equal(classifyClassName('search-modal-input'), 'search');
+  assert.equal(classifyClassName('site-footer-navigation-link'), 'footer');
+  assert.equal(classifyClassName('page-backlinks-list'), 'page-actions');
+  assert.equal(classifyClassName('graph-modal'), 'embeds');
+  assert.equal(classifyClassName('not-found-title'), 'errors');
+  assert.equal(classifyClassName('is-current'), 'states');
+  assert.equal(classifyClassName('made-up-hook'), 'unclassified');
+});
+
+test('every class in the default theme has an intentional group', async () => {
+  const css = await readFile(
+    'apps/flowershow/styles/default-theme.css',
+    'utf8',
+  );
+  const unclassified = extractClassNames(css).filter(
+    (className) => classifyClassName(className) === 'unclassified',
+  );
+
+  assert.deepEqual(unclassified, []);
+});
+
+test('generateReference documents structure, stability, and each class once', () => {
+  const output = generateReference(fixtureCss);
+
+  assert.match(output, /^---\ntitle: Semantic theme class reference/m);
+  assert.match(output, /Stability contract/);
+  assert.match(output, /DOM shape/);
+  assert.match(output, /5 unique class hooks/);
+  assert.match(output, /State/);
+  assert.match(output, /Variant/);
+  assert.match(output, /Element/);
+
+  for (const className of extractClassNames(fixtureCss)) {
+    const occurrences = output.split(`<code>.${className}</code>`).length - 1;
+    assert.equal(
+      occurrences,
+      1,
+      `${className} should occur once in the tables`,
+    );
+  }
+});
+
+test('runCli writes deterministic output and detects drift', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'theme-class-reference-'));
+  const cssPath = join(directory, 'default-theme.css');
+  const outputPath = join(directory, 'theme-class-reference.md');
+  const messages = [];
+  const io = {
+    cssPath,
+    outputPath,
+    log: (message) => messages.push(message),
+    error: (message) => messages.push(message),
+  };
+
+  await writeFile(cssPath, fixtureCss);
+
+  assert.equal(await runCli(['--check'], io), 1);
+  assert.match(messages.at(-1), /out of date/);
+
+  assert.equal(await runCli(['--write'], io), 0);
+  const firstOutput = await readFile(outputPath, 'utf8');
+  assert.equal(firstOutput, generateReference(fixtureCss));
+
+  assert.equal(await runCli(['--check'], io), 0);
+
+  await writeFile(outputPath, `${firstOutput}\nstale\n`);
+  assert.equal(await runCli(['--check'], io), 1);
+});


### PR DESCRIPTION
## Summary

- publish a generated reference for all 230 class hooks styled by `default-theme.css`, grouped into 12 UI areas with DOM sketches
- distinguish state, variant, element, and component hooks and state the public stability contract
- add deterministic write/check commands, run drift checking in lint, and run generator tests in the root test suite
- link the new reference prominently from the custom-styles guide

Emitted-only classes that are not styled by `default-theme.css` remain outside this documented contract until intentionally adopted there. The separate malformed `.is-linked` component hook remains tracked in #1343. The existing `/docs/reference/themes` page is unchanged.

## Verification

- `pnpm docs:theme-classes:check`
- `pnpm lint`
- `pnpm test` (includes the new Node test suite; 5 new tests plus all existing tests pass)
- `git diff --exit-code 5534810e..HEAD -- content/flowershow-app/docs/reference/themes.md`

Closes #1338
Part of #1364