### PR TITLE
fix(cli): respect contentExclude/contentInclude from config.json

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.3.0
+
+- Fix: `fl publish` now respects `contentExclude`/`contentInclude` in `config.json`, matching the visibility rules the GitHub-sync build already applies. Previously the CLI ignored `config.json` entirely, so excluded paths (e.g. drafts, internal notes) were published and served even though the GitHub-sync build correctly hid them for the same repo.
+
 ## 2.2.0
 
 - Recover gracefully when a site has been renamed on the server. Previously, if the stored site name no longer matched (e.g. after the site-name unification), `fl` reported the site as deleted, removed the local `.flowershow`, and could create a duplicate site. It now recognises a likely rename, keeps `.flowershow` intact, and offers to re-point the folder to the site's current name.

--- a/apps/cli/cmd/publish.go
+++ b/apps/cli/cmd/publish.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flowershow/publish/internal/config"
 	"github.com/flowershow/publish/internal/files"
 	"github.com/flowershow/publish/internal/localconfig"
+	"github.com/flowershow/publish/internal/siteconfig"
 	"github.com/flowershow/publish/internal/telemetry"
 	"github.com/flowershow/publish/internal/ui"
 	"github.com/spf13/cobra"
@@ -112,6 +113,12 @@ func runPublish(inputPaths []string, nameFlag string, skipConfirm bool) error {
 		})
 		return nil
 	}
+	// Apply config.json's contentInclude/contentExclude, matching the
+	// visibility rules the GitHub-sync build applies to the same config.json.
+	if isFolderMode {
+		discovered = siteconfig.ApplyVisibility(discovered, folderPath)
+	}
+
 	if err := files.ValidateFiles(discovered); err != nil {
 		sp.Fail("Validation failed")
 		ui.PrintError(err.Error())

--- a/apps/cli/cmd/sync.go
+++ b/apps/cli/cmd/sync.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flowershow/publish/internal/auth"
 	"github.com/flowershow/publish/internal/config"
 	"github.com/flowershow/publish/internal/files"
+	"github.com/flowershow/publish/internal/siteconfig"
 	"github.com/flowershow/publish/internal/telemetry"
 	"github.com/flowershow/publish/internal/ui"
 	"github.com/spf13/cobra"
@@ -84,6 +85,10 @@ func runSync(inputPath, siteName string, dryRun, verbose bool) error {
 		})
 		return nil
 	}
+	// Apply config.json's contentInclude/contentExclude, matching the
+	// visibility rules the GitHub-sync build applies to the same config.json.
+	discovered = siteconfig.ApplyVisibility(discovered, absPath)
+
 	if err := files.ValidateFiles(discovered); err != nil {
 		sp.Fail("Validation failed")
 		ui.PrintError(err.Error())

--- a/apps/cli/internal/config/config.go
+++ b/apps/cli/internal/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import "os"
 
-var Version = "2.2.0"
+var Version = "2.3.0"
 
 func APIURL() string {
 	if v := os.Getenv("API_URL"); v != "" {

--- a/apps/cli/internal/files/visibility.go
+++ b/apps/cli/internal/files/visibility.go
@@ -1,0 +1,58 @@
+package files
+
+import "strings"
+
+// IsPathVisible mirrors the GitHub-sync workflow's isPathVisible logic
+// (apps/cloudflare-worker/src/github-sync-workflow.js) so `fl publish`
+// respects the same contentInclude/contentExclude rules as the GitHub-sync
+// build for the same config.json.
+func IsPathVisible(path string, includes, excludes []string) bool {
+	normalized := normalizeURLPath(path)
+	if normalized == "/config.json" || normalized == "/custom.css" {
+		return true
+	}
+	if isPathIncluded(path, excludes) {
+		return false
+	}
+	if isPathIncluded(path, includes) {
+		return true
+	}
+	// Mirrors JS `return !includes[0]`: falls back to visible unless the
+	// first entry is a non-empty string. An empty-string first entry (an
+	// edge case a hand-edited config.json could produce) must default to
+	// visible, matching the GitHub-sync build exactly.
+	return len(includes) == 0 || includes[0] == ""
+}
+
+func normalizeURLPath(p string) string {
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	return strings.TrimSuffix(p, "/")
+}
+
+func isPathIncluded(path string, collection []string) bool {
+	p := normalizeURLPath(path)
+	for _, item := range collection {
+		item = normalizeURLPath(item)
+		if item == p || strings.HasPrefix(p, item+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// FilterVisible returns the subset of files visible under the given
+// contentInclude/contentExclude rules, preserving order.
+func FilterVisible(fileList []FileInfo, includes, excludes []string) []FileInfo {
+	if len(includes) == 0 && len(excludes) == 0 {
+		return fileList
+	}
+	out := make([]FileInfo, 0, len(fileList))
+	for _, f := range fileList {
+		if IsPathVisible(f.Path, includes, excludes) {
+			out = append(out, f)
+		}
+	}
+	return out
+}

--- a/apps/cli/internal/files/visibility_test.go
+++ b/apps/cli/internal/files/visibility_test.go
@@ -1,0 +1,96 @@
+package files
+
+import "testing"
+
+func TestIsPathVisible_NoFilters(t *testing.T) {
+	if !IsPathVisible("secret/page.md", nil, nil) {
+		t.Fatal("expected visible when no includes/excludes")
+	}
+}
+
+func TestIsPathVisible_ExcludesDirectory(t *testing.T) {
+	excludes := []string{"/secret"}
+	if IsPathVisible("secret/page.md", nil, excludes) {
+		t.Fatal("expected secret/page.md to be excluded by /secret")
+	}
+	if !IsPathVisible("public/page.md", nil, excludes) {
+		t.Fatal("expected public/page.md to remain visible")
+	}
+}
+
+func TestIsPathVisible_ExactExclude(t *testing.T) {
+	excludes := []string{"/notes/private.md"}
+	if IsPathVisible("notes/private.md", nil, excludes) {
+		t.Fatal("expected exact-match exclude to hide the file")
+	}
+	if !IsPathVisible("notes/public.md", nil, excludes) {
+		t.Fatal("sibling file should remain visible")
+	}
+}
+
+func TestIsPathVisible_IncludesOnlyAllowsListed(t *testing.T) {
+	includes := []string{"/public"}
+	if !IsPathVisible("public/page.md", includes, nil) {
+		t.Fatal("expected included path to be visible")
+	}
+	if IsPathVisible("secret/page.md", includes, nil) {
+		t.Fatal("expected path not covered by includes to be hidden")
+	}
+}
+
+func TestIsPathVisible_ExcludeTakesPrecedenceOverInclude(t *testing.T) {
+	includes := []string{"/"}
+	excludes := []string{"/secret"}
+	if IsPathVisible("secret/page.md", includes, excludes) {
+		t.Fatal("expected excludes to win over includes")
+	}
+}
+
+func TestIsPathVisible_EmptyStringFirstIncludeDefaultsToVisible(t *testing.T) {
+	// Mirrors the JS reference's `return !includes[0]`: a falsy first entry
+	// (e.g. a stray empty string from a hand-edited config.json) must fall
+	// back to "visible", not "hidden", for paths matched by neither list.
+	includes := []string{"", "/public"}
+	if !IsPathVisible("other/page.md", includes, nil) {
+		t.Fatal("expected unmatched path to default to visible when includes[0] is empty")
+	}
+}
+
+func TestIsPathVisible_ConfigJsonAlwaysVisible(t *testing.T) {
+	includes := []string{"/public"}
+	excludes := []string{"/"}
+	if !IsPathVisible("config.json", includes, excludes) {
+		t.Fatal("config.json must always be visible")
+	}
+	if !IsPathVisible("custom.css", includes, excludes) {
+		t.Fatal("custom.css must always be visible")
+	}
+}
+
+func TestFilterVisible(t *testing.T) {
+	input := []FileInfo{
+		{Path: "index.md"},
+		{Path: "public/page.md"},
+		{Path: "secret/page.md"},
+	}
+	out := FilterVisible(input, nil, []string{"/secret"})
+	if len(out) != 2 {
+		t.Fatalf("expected 2 visible files, got %d", len(out))
+	}
+	for _, f := range out {
+		if f.Path == "secret/page.md" {
+			t.Fatal("secret/page.md should have been filtered out")
+		}
+	}
+}
+
+func TestFilterVisible_PreservesOrderAndNoFilters(t *testing.T) {
+	input := []FileInfo{
+		{Path: "index.md"},
+		{Path: "public/page.md"},
+	}
+	out := FilterVisible(input, nil, nil)
+	if len(out) != 2 {
+		t.Fatalf("expected all files to pass through, got %d", len(out))
+	}
+}

--- a/apps/cli/internal/siteconfig/siteconfig.go
+++ b/apps/cli/internal/siteconfig/siteconfig.go
@@ -1,0 +1,52 @@
+package siteconfig
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/flowershow/publish/internal/files"
+)
+
+const FileName = "config.json"
+
+// Config holds the subset of config.json fields the CLI needs to replicate
+// GitHub-sync's content visibility rules.
+type Config struct {
+	ContentInclude []string `json:"contentInclude"`
+	ContentExclude []string `json:"contentExclude"`
+}
+
+// Read reads config.json from dirPath.
+// Returns nil if the file doesn't exist or is invalid.
+func Read(dirPath string) *Config {
+	data, err := os.ReadFile(filepath.Join(dirPath, FileName))
+	if err != nil {
+		return nil
+	}
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil
+	}
+	return &cfg
+}
+
+// ApplyVisibility reads config.json from dirPath (if present) and filters
+// discovered down to the files visible under its contentInclude/contentExclude
+// rules, matching the GitHub-sync build's behavior for the same config.json.
+// If dirPath has no valid config.json, discovered is returned unchanged.
+func ApplyVisibility(discovered []files.FileInfo, dirPath string) []files.FileInfo {
+	cfg := Read(dirPath)
+	if cfg == nil {
+		return discovered
+	}
+	var projectName string
+	if len(discovered) > 0 {
+		projectName = discovered[0].ProjectName
+	}
+	filtered := files.FilterVisible(discovered, cfg.ContentInclude, cfg.ContentExclude)
+	if len(filtered) > 0 {
+		filtered[0].ProjectName = projectName
+	}
+	return filtered
+}

--- a/apps/cli/internal/siteconfig/siteconfig_test.go
+++ b/apps/cli/internal/siteconfig/siteconfig_test.go
@@ -1,0 +1,72 @@
+package siteconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/flowershow/publish/internal/files"
+)
+
+func TestRead_ParsesContentExcludeAndInclude(t *testing.T) {
+	dir := t.TempDir()
+	body := `{"title": "fl exclude test", "contentExclude": ["/secret"], "contentInclude": ["/public"]}`
+	if err := os.WriteFile(filepath.Join(dir, FileName), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := Read(dir)
+	if cfg == nil {
+		t.Fatal("expected config to be parsed")
+	}
+	if len(cfg.ContentExclude) != 1 || cfg.ContentExclude[0] != "/secret" {
+		t.Fatalf("unexpected ContentExclude: %v", cfg.ContentExclude)
+	}
+	if len(cfg.ContentInclude) != 1 || cfg.ContentInclude[0] != "/public" {
+		t.Fatalf("unexpected ContentInclude: %v", cfg.ContentInclude)
+	}
+}
+
+func TestRead_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	if cfg := Read(dir); cfg != nil {
+		t.Fatalf("expected nil config for missing file, got %+v", cfg)
+	}
+}
+
+func TestRead_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, FileName), []byte("{not json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if cfg := Read(dir); cfg != nil {
+		t.Fatalf("expected nil config for invalid JSON, got %+v", cfg)
+	}
+}
+
+func TestApplyVisibility_FiltersAndPreservesProjectName(t *testing.T) {
+	dir := t.TempDir()
+	body := `{"contentExclude": ["/secret"]}`
+	if err := os.WriteFile(filepath.Join(dir, FileName), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+	discovered := []files.FileInfo{
+		{Path: "secret/page.md", ProjectName: "myproject"},
+		{Path: "public/page.md"},
+	}
+	out := ApplyVisibility(discovered, dir)
+	if len(out) != 1 || out[0].Path != "public/page.md" {
+		t.Fatalf("expected only public/page.md to survive, got %+v", out)
+	}
+	if out[0].ProjectName != "myproject" {
+		t.Fatalf("expected ProjectName to be carried over to the new first element, got %q", out[0].ProjectName)
+	}
+}
+
+func TestApplyVisibility_NoConfigReturnsUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	discovered := []files.FileInfo{{Path: "index.md", ProjectName: "myproject"}}
+	out := ApplyVisibility(discovered, dir)
+	if len(out) != 1 || out[0].Path != "index.md" || out[0].ProjectName != "myproject" {
+		t.Fatalf("expected discovered to pass through unchanged, got %+v", out)
+	}
+}


### PR DESCRIPTION
## Summary
- `fl publish`/`fl sync` never read `config.json`, so `contentExclude`/`contentInclude` were silently ignored — excluded paths (drafts, internal notes) were uploaded and served with 200s even though the GitHub-sync build correctly hides them for the same `config.json`.
- Ports GitHub-sync's `isPathVisible` filtering logic (`apps/cloudflare-worker/src/github-sync-workflow.js`) to Go (`internal/files/visibility.go`), including the same `config.json`/`custom.css`-always-visible and exclude-wins-over-include semantics.
- Adds `internal/siteconfig` to read `config.json` and a shared `ApplyVisibility` helper (used by both `publish.go` and `sync.go`) that filters discovered files and preserves `ProjectName` correctly if the first file is filtered out.
- As a side effect, this also fixes the related "`Deleted: 0`" symptom for files newly covered by `contentExclude` — since they're no longer sent to the sync API, the server's existing diff logic now deletes them correctly.
- Bumps CLI to 2.3.0 with a CHANGELOG entry.

Fixes #1362.

## Test plan
- [x] `go build ./...` and `go test ./...` pass for all touched packages (`internal/files`, `internal/siteconfig`, `cmd`)
- [x] Unit tests cover: directory-prefix exclude, exact-path exclude, includes-restrict-to-listed, exclude-precedence-over-include, `config.json`/`custom.css` always visible, the `!includes[0]`-falsy edge case, and `ProjectName` preservation across filtering
- [x] Manually reproduced the issue's exact repro tree and confirmed `/secret/page` is excluded while `config.json` and `/public/page` remain visible
- [ ] Release: shipping this requires merging to `main` and then pushing a `cli/v2.3.0` tag to trigger `.github/workflows/release-cli-go.yml` — not done yet, pending review/merge

https://claude.ai/code/session_01De6V4dYjyuV7EuJ3ZArhYB